### PR TITLE
[codex] refine habit and protocol creation flow

### DIFF
--- a/app/(auth)/habit/createProtocol.tsx
+++ b/app/(auth)/habit/createProtocol.tsx
@@ -1,0 +1,5 @@
+import CreateProtocolScreen from "@/features/habit/screens/CreateProtocolScreen";
+
+export default function CreateProtocolRoute() {
+  return <CreateProtocolScreen />;
+}

--- a/components/ui/CustomTabBar.tsx
+++ b/components/ui/CustomTabBar.tsx
@@ -24,10 +24,6 @@ const CustomTabBar: React.FC<BottomTabBarProps> = ({
   const styles = styling(newTheme, spacing);
 
   const onPlusPress = () => {
-    // Usually opens a "Create" modal or screen
-    // For now, we can navigate to habit creation if it exists
-    router.push("/(auth)/habit/createHabit");
-    // =======
     setModalVisible(true);
   };
 

--- a/components/ui/modal/CreateActionModal.tsx
+++ b/components/ui/modal/CreateActionModal.tsx
@@ -112,7 +112,7 @@ const CreateActionModal: React.FC<CreateActionModalProps> = ({
               iconBg="rgba(163, 190, 140, 0.15)"
               title="Craft Unique Formula"
               description="Design a ritual tailored to your specific neural architecture."
-              onPress={() => handleAction("/(auth)/habit/createHabit")}
+              onPress={() => handleAction("/(auth)/habit/createProtocol")}
               svaTypography={svaTypography}
               styles={styles}
             />

--- a/components/ui/modal/CreateActionModal.tsx
+++ b/components/ui/modal/CreateActionModal.tsx
@@ -22,7 +22,8 @@ const CreateActionModal: React.FC<CreateActionModalProps> = ({
   visible,
   onClose,
 }) => {
-  const { newTheme, spacing, typography } = React.useContext(ThemeContext);
+  const { spacing, svaTypography, svaColors } =
+    React.useContext(ThemeContext);
 
   const fadeAnim = useRef(new Animated.Value(0)).current;
   const slideAnim = useRef(new Animated.Value(20)).current;
@@ -63,13 +64,12 @@ const CreateActionModal: React.FC<CreateActionModalProps> = ({
 
   const handleAction = (route: any) => {
     onClose();
-    // Use a small timeout to allow modal to close before navigating
     setTimeout(() => {
       router.push(route);
     }, 100);
   };
 
-  const styles = styling(newTheme, spacing, typography);
+  const styles = styling(spacing, svaTypography, svaColors);
 
   return (
     <Modal
@@ -93,32 +93,38 @@ const CreateActionModal: React.FC<CreateActionModalProps> = ({
             },
           ]}
         >
+          <View style={styles.dragHandle} />
+          
+          <Pressable onPress={onClose} style={styles.closeButton}>
+            <View style={styles.closeIconBg}>
+              <Ionicons name="close" size={20} color={svaColors.text.secondary} />
+            </View>
+          </Pressable>
+
           <View style={styles.header}>
-            <Text style={styles.title}>What would you like to create?</Text>
-            <Pressable onPress={onClose} style={styles.closeButton}>
-              <Ionicons name="close" size={24} color={newTheme.textSecondary} />
-            </Pressable>
+            <Text style={styles.title}>Initiate Ritual</Text>
+            <Text style={styles.subtitle}>CHOOSE A PATH TO ALIGN YOUR FREQUENCY</Text>
           </View>
 
           <View style={styles.optionsContainer}>
             <ActionOption
-              icon="sparkles-outline"
-              title="Custom Ritual"
-              description="Design a personal habit from scratch"
-              onPress={() => handleAction("/(auth)/habit/CreateHabitScreen")}
-              theme={newTheme}
-              spacing={spacing}
-              typography={typography}
+              icon={<Ionicons name="flash" size={24} color={svaColors.brand.primary} />}
+              iconBg="rgba(163, 190, 140, 0.15)"
+              title="Craft Unique Formula"
+              description="Design a ritual tailored to your specific neural architecture."
+              onPress={() => handleAction("/(auth)/habit/createHabit")}
+              svaTypography={svaTypography}
+              styles={styles}
             />
 
             <ActionOption
-              icon="library-outline"
-              title="Import from Library"
-              description="Choose from our curated routine templates"
-              onPress={() => handleAction("/(auth)/toolsScreen/RoutineScreen")}
-              theme={newTheme}
-              spacing={spacing}
-              typography={typography}
+              icon={<Ionicons name="book-outline" size={24} color={svaColors.text.secondary} />}
+              iconBg="rgba(255, 255, 255, 0.05)"
+              title="Curated Manifests"
+              description="Adopt expertly designed biological rhythms."
+              onPress={() => handleAction("/(auth)/tools/templateRoutineList")}
+              svaTypography={svaTypography}
+              styles={styles}
             />
           </View>
         </Animated.View>
@@ -128,114 +134,74 @@ const CreateActionModal: React.FC<CreateActionModalProps> = ({
 };
 
 interface ActionOptionProps {
-  icon: any;
+  icon: React.ReactNode;
+  iconBg: string;
   title: string;
   description: string;
   onPress: () => void;
-  theme: any;
-  spacing: any;
-  typography: any;
+  svaTypography: any;
+  styles: any;
 }
 
 const ActionOption: React.FC<ActionOptionProps> = ({
   icon,
+  iconBg,
   title,
   description,
   onPress,
-  theme,
-  spacing,
-  typography,
+  svaTypography,
+  styles,
 }) => {
   return (
     <Pressable
       onPress={onPress}
       style={({ pressed }) => [
+        styles.optionPressable,
         {
-          padding: spacing.md,
-          flexDirection: "row",
-          alignItems: "center",
-          borderRadius: 20,
           backgroundColor: pressed
             ? "rgba(255,255,255,0.06)"
             : "rgba(255,255,255,0.02)",
-          borderWidth: 1,
           borderColor: pressed
             ? "rgba(255,255,255,0.1)"
             : "rgba(255,255,255,0.05)",
         },
       ]}
     >
-      <View
-        style={{
-          width: 52,
-          height: 52,
-          borderRadius: 16,
-          backgroundColor: "rgba(163, 190, 140, 0.15)",
-          justifyContent: "center",
-          alignItems: "center",
-          marginRight: spacing.md,
-        }}
-      >
-        <Ionicons name={icon} size={26} color={theme.accent} />
+      <View style={[styles.optionIconContainer, { backgroundColor: iconBg }]}>
+        {icon}
       </View>
       <View style={{ flex: 1 }}>
-        <Text
-          style={{
-            ...typography.body,
-            fontSize: 17,
-            fontWeight: "700",
-            color: theme.textPrimary,
-            marginBottom: 4,
-          }}
-        >
+        <Text style={[styles.optionTitle, svaTypography.textStyle.bodyMedium]}>
           {title}
         </Text>
-        <Text
-          style={{
-            ...typography.caption,
-            fontSize: 13,
-            color: theme.textSecondary,
-            lineHeight: 18,
-          }}
-        >
+        <Text style={[styles.optionDescription, svaTypography.textStyle.caption]}>
           {description}
         </Text>
-      </View>
-      <View
-        style={{
-          width: 32,
-          height: 32,
-          borderRadius: 16,
-          backgroundColor: "rgba(255,255,255,0.05)",
-          justifyContent: "center",
-          alignItems: "center",
-        }}
-      >
-        <Ionicons name="chevron-forward" size={18} color={theme.accent} />
       </View>
     </Pressable>
   );
 };
 
-const styling = (theme: any, spacing: any, typography: any) =>
+const styling = (spacing: any, svaTypography: any, svaColors: any) =>
   StyleSheet.create({
     backdrop: {
       ...StyleSheet.absoluteFillObject,
-      backgroundColor: "rgba(0, 0, 0, 0.7)",
+      backgroundColor: svaColors.overlay.strong,
     },
     centeredView: {
       flex: 1,
       justifyContent: "flex-end",
       alignItems: "center",
       paddingHorizontal: spacing.md,
-      paddingBottom: 120, // Clear the bottom tab bar
+      paddingBottom: 120,
     },
     modalView: {
       width: "100%",
-      backgroundColor: theme.surface,
+      backgroundColor: svaColors.bg.base,
       borderRadius: 32,
       padding: spacing.lg,
-      shadowColor: "#000",
+      paddingTop: spacing.md,
+      shadowColor: svaColors.shadow.default,
       shadowOffset: {
         width: 0,
         height: -10,
@@ -244,24 +210,74 @@ const styling = (theme: any, spacing: any, typography: any) =>
       shadowRadius: 20,
       elevation: 20,
       borderWidth: 1,
-      borderColor: "rgba(255, 255, 255, 0.08)",
+      borderColor: svaColors.border.subtle,
     },
-    header: {
-      flexDirection: "row",
-      justifyContent: "space-between",
-      alignItems: "center",
-      marginBottom: spacing.md,
-      paddingLeft: spacing.xs,
-    },
-    title: {
-      ...typography.h3,
-      color: theme.textPrimary,
+    dragHandle: {
+      width: 40,
+      height: 4,
+      backgroundColor: svaColors.border.default,
+      borderRadius: 2,
+      alignSelf: "center",
+      marginBottom: spacing.sm,
     },
     closeButton: {
-      padding: spacing.xs,
+      position: "absolute",
+      top: spacing.md,
+      right: spacing.md,
+      zIndex: 10,
+    },
+    closeIconBg: {
+      width: 32,
+      height: 32,
+      borderRadius: 16,
+      backgroundColor: svaColors.surface.raised,
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    header: {
+      alignItems: "center",
+      marginBottom: spacing.xl,
+      marginTop: spacing.md,
+    },
+    title: {
+      ...svaTypography.textStyle.authTitle,
+      color: svaColors.text.primary,
+      fontSize: 28,
+      textAlign: "center",
+    },
+    subtitle: {
+      ...svaTypography.textStyle.authTinyLabel,
+      color: svaColors.text.secondary,
+      textAlign: "center",
+      marginTop: spacing.xs,
     },
     optionsContainer: {
       gap: spacing.md,
+    },
+    optionPressable: {
+      padding: spacing.md,
+      flexDirection: "row",
+      alignItems: "center",
+      borderRadius: 20,
+      borderWidth: 1,
+    },
+    optionIconContainer: {
+      width: 48,
+      height: 48,
+      borderRadius: 12,
+      justifyContent: "center",
+      alignItems: "center",
+      marginRight: spacing.md,
+    },
+    optionTitle: {
+      color: svaColors.text.primary,
+      fontSize: 18,
+      marginBottom: 4,
+    },
+    optionDescription: {
+      color: svaColors.text.secondary,
+      fontSize: 14,
+      lineHeight: 20,
     },
   });
 

--- a/components/ui/modal/ModalHeader.tsx
+++ b/components/ui/modal/ModalHeader.tsx
@@ -1,0 +1,115 @@
+import React, { useContext, useMemo } from "react";
+import {
+  Text,
+  TouchableOpacity,
+  View,
+  StyleSheet,
+  StyleProp,
+  TextStyle,
+  ViewStyle,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+
+import ThemeContext from "@/contexts/ThemeContext";
+
+type ModalHeaderProps = {
+  title: string;
+  subtitle?: string;
+  onClose: () => void;
+  accessibilityLabel?: string;
+  style?: StyleProp<ViewStyle>;
+  titleStyle?: StyleProp<TextStyle>;
+  subtitleStyle?: StyleProp<TextStyle>;
+  closeButtonStyle?: StyleProp<ViewStyle>;
+  iconSize?: number;
+};
+
+export default function ModalHeader({
+  title,
+  subtitle,
+  onClose,
+  accessibilityLabel = "Close",
+  style,
+  titleStyle,
+  subtitleStyle,
+  closeButtonStyle,
+  iconSize = 22,
+}: ModalHeaderProps) {
+  const { newTheme, svaColors } = useContext(ThemeContext);
+
+  const colors = useMemo(
+    () => ({
+      textPrimary: svaColors.text.primary ?? newTheme.textPrimary,
+      textSecondary: svaColors.text.secondary ?? newTheme.textSecondary,
+    }),
+    [newTheme, svaColors]
+  );
+
+  const styles = useMemo(() => makeStyles(colors), [colors]);
+  const hasSubtitle = !!subtitle?.trim();
+
+  return (
+    <View
+      style={[
+        styles.header,
+        hasSubtitle && styles.headerWithSubtitle,
+        style,
+      ]}
+    >
+      <View style={styles.textWrap}>
+        <Text style={[styles.title, titleStyle]} numberOfLines={1}>
+          {title}
+        </Text>
+        {hasSubtitle ? (
+          <Text style={[styles.subtitle, subtitleStyle]}>{subtitle}</Text>
+        ) : null}
+      </View>
+
+      <TouchableOpacity
+        onPress={onClose}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityRole="button"
+        hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+        style={[styles.closeButton, closeButtonStyle]}
+        activeOpacity={0.85}
+      >
+        <Ionicons name="close" size={iconSize} color={colors.textPrimary} />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const makeStyles = (colors: { textPrimary: string; textSecondary: string }) =>
+  StyleSheet.create({
+    header: {
+      width: "100%",
+      paddingHorizontal: 18,
+      paddingTop: 18,
+      paddingBottom: 10,
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+    },
+    headerWithSubtitle: {
+      alignItems: "flex-start",
+    },
+    textWrap: {
+      flex: 1,
+      paddingRight: 12,
+    },
+    title: {
+      fontSize: 18,
+      fontWeight: "700",
+      color: colors.textPrimary,
+    },
+    subtitle: {
+      marginTop: 4,
+      fontSize: 13,
+      lineHeight: 18,
+      color: colors.textSecondary,
+    },
+    closeButton: {
+      padding: 4,
+      borderRadius: 999,
+    },
+  });

--- a/components/ui/modal/ProcessingModal.tsx
+++ b/components/ui/modal/ProcessingModal.tsx
@@ -1,0 +1,189 @@
+import React, { useContext, useMemo } from "react";
+import {
+  ActivityIndicator,
+  Modal,
+  Platform,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+
+import ThemeContext from "@/contexts/ThemeContext";
+
+type ProcessingModalProps = {
+  visible: boolean;
+  title?: string;
+  subtitle?: string;
+  message?: string;
+};
+
+export default function ProcessingModal({
+  visible,
+  title = "Processing",
+  subtitle = "Please wait while we finish your request.",
+  message = "We're sending this to the backend and preparing the next screen.",
+}: ProcessingModalProps) {
+  const { newTheme, spacing, svaColors, svaTypography, typography } =
+    useContext(ThemeContext);
+
+  const bodyTextStyle = svaTypography?.textStyle?.body ?? typography.body;
+
+  const styles = useMemo(
+    () => makeStyles(newTheme, spacing, svaColors, bodyTextStyle, svaTypography),
+    [bodyTextStyle, newTheme, spacing, svaColors, svaTypography]
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      statusBarTranslucent
+      onRequestClose={() => {}}
+    >
+      <View style={styles.overlay}>
+        <View style={styles.backdrop} />
+
+        <View style={styles.center} pointerEvents="box-none">
+          <View style={styles.card}>
+            <View style={styles.topAccent} />
+
+            <View style={styles.spinnerWrap}>
+              <View style={styles.spinnerFrame}>
+                <ActivityIndicator
+                  size="large"
+                  color={svaColors.brand.primary ?? newTheme.accent}
+                />
+              </View>
+            </View>
+
+            <View style={styles.header}>
+              <Text style={styles.title}>{title}</Text>
+              {subtitle ? (
+                <Text style={styles.subtitle}>{subtitle}</Text>
+              ) : null}
+            </View>
+
+            <View style={styles.messagePill}>
+              <Text style={styles.message}>{message}</Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const makeStyles = (
+  t: any,
+  spacing: any,
+  svaColors: any,
+  bodyTextStyle: any,
+  svaTypography: any
+) =>
+  StyleSheet.create({
+    overlay: {
+      flex: 1,
+    },
+    backdrop: {
+      ...StyleSheet.absoluteFillObject,
+      backgroundColor: t.overlayStrong ?? "rgba(12,14,11,0.62)",
+    },
+    center: {
+      ...StyleSheet.absoluteFillObject,
+      justifyContent: "center",
+      alignItems: "center",
+      paddingHorizontal: spacing.xl,
+    },
+    card: {
+      width: "100%",
+      maxWidth: 360,
+      borderRadius: 30,
+      backgroundColor: t.cardRaised ?? t.surfaceMuted ?? t.surface,
+      borderWidth: 1,
+      borderColor: t.borderMuted ?? t.border,
+      overflow: "hidden",
+      paddingHorizontal: spacing.xl,
+      paddingTop: spacing.lg,
+      paddingBottom: spacing.xl,
+      alignItems: "center",
+      ...Platform.select({
+        ios: {
+          shadowColor: "#000",
+          shadowOpacity: 0.22,
+          shadowOffset: { width: 0, height: 12 },
+          shadowRadius: 28,
+        },
+        android: { elevation: 18 },
+      }),
+    },
+    topAccent: {
+      width: 58,
+      height: 4,
+      borderRadius: 999,
+      backgroundColor: t.borderMuted ?? t.border,
+      marginBottom: spacing.md,
+    },
+    spinnerWrap: {
+      width: "100%",
+      alignItems: "center",
+    },
+    spinnerFrame: {
+      width: 92,
+      height: 92,
+      borderRadius: 46,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: t.surface ?? t.background,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: t.borderMuted ?? t.border,
+      ...Platform.select({
+        ios: {
+          shadowColor: "#000",
+          shadowOpacity: 0.16,
+          shadowOffset: { width: 0, height: 10 },
+          shadowRadius: 22,
+        },
+        android: { elevation: 4 },
+      }),
+    },
+    header: {
+      width: "100%",
+      alignItems: "center",
+      paddingTop: spacing.lg,
+    },
+    title: {
+      ...(svaTypography?.textStyle?.displayMedium ?? {}),
+      fontSize: 24,
+      lineHeight: 28,
+      color: t.textPrimary,
+      fontStyle: "normal",
+      textAlign: "center",
+    },
+    subtitle: {
+      ...bodyTextStyle,
+      marginTop: 6,
+      fontSize: 13,
+      lineHeight: 18,
+      color: t.textSecondary,
+      textAlign: "center",
+    },
+    messagePill: {
+      marginTop: spacing.lg,
+      width: "100%",
+      borderRadius: 20,
+      paddingHorizontal: spacing.lg,
+      paddingVertical: spacing.md,
+      backgroundColor: t.surfaceMuted ?? t.background,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: t.borderMuted ?? t.border,
+      alignItems: "center",
+    },
+    message: {
+      color: t.textPrimary,
+      fontSize: 14,
+      lineHeight: 20,
+      fontWeight: "600",
+      textAlign: "center",
+    },
+  });

--- a/components/ui/modal/SelectableListModal.tsx
+++ b/components/ui/modal/SelectableListModal.tsx
@@ -15,6 +15,7 @@ import {
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import ThemeContext from "@/contexts/ThemeContext";
+import ModalHeader from "@/components/ui/modal/ModalHeader";
 
 export type SelectableItem = {
   id: string | number;
@@ -154,22 +155,7 @@ export default function SelectableListModal<T extends SelectableItem>({
         ]}
       >
         <View style={[styles.card, style]}>
-          {/* Header */}
-          <View style={styles.header}>
-            <Text style={styles.headerTitle} accessibilityRole="header">
-              {title}
-            </Text>
-
-            <Pressable
-              onPress={onClose}
-              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-              accessibilityLabel="Close"
-              accessibilityRole="button"
-              style={styles.closeBtn}
-            >
-              <Ionicons name="close" size={22} color={newTheme.textPrimary} />
-            </Pressable>
-          </View>
+          <ModalHeader title={title} onClose={onClose} />
 
           <FlatList
             data={options}
@@ -212,23 +198,6 @@ const makeStyles = (t: any, spacing: any) =>
         },
         android: { elevation: 12 },
       }),
-    },
-
-    header: {
-      paddingHorizontal: 18,
-      paddingTop: 18,
-      paddingBottom: 10,
-      flexDirection: "row",
-      alignItems: "center",
-      justifyContent: "space-between",
-    },
-    headerTitle: {
-      fontSize: 20,
-      fontWeight: "700",
-      color: t.textPrimary,
-    },
-    closeBtn: {
-      padding: 2,
     },
 
     separator: {

--- a/components/ui/picker/TimePickerSheet.tsx
+++ b/components/ui/picker/TimePickerSheet.tsx
@@ -13,9 +13,9 @@ import {
 import DateTimePicker, {
   DateTimePickerEvent,
 } from "@react-native-community/datetimepicker";
-import { Ionicons } from "@expo/vector-icons";
 
 import ThemeContext from "@/contexts/ThemeContext";
+import ModalHeader from "@/components/ui/modal/ModalHeader";
 
 type Props = {
   visible: boolean;
@@ -108,20 +108,7 @@ export default function TimePickerSheet({
             },
           ]}
         >
-          {/* Header */}
-          <View style={styles.header}>
-            <Text style={[styles.title, { color: newTheme.textPrimary }]}>
-              {title}
-            </Text>
-
-            <TouchableOpacity
-              onPress={onClose}
-              hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
-              accessibilityLabel="Close time picker"
-            >
-              <Ionicons name="close" size={20} color={newTheme.textPrimary} />
-            </TouchableOpacity>
-          </View>
+          <ModalHeader title={title} onClose={onClose} />
 
           {/* Picker */}
           <View style={styles.picker}>
@@ -185,18 +172,6 @@ const createStyles = (t: any) =>
         },
         android: { elevation: 16 },
       }),
-    },
-    header: {
-      paddingHorizontal: 16,
-      paddingTop: 14,
-      paddingBottom: 10,
-      flexDirection: "row",
-      alignItems: "center",
-      justifyContent: "space-between",
-    },
-    title: {
-      fontSize: 16,
-      fontWeight: "700",
     },
     picker: {
       paddingBottom: Platform.OS === "ios" ? 8 : 0,

--- a/features/habit/components/create-habit/HabitDateInput.tsx
+++ b/features/habit/components/create-habit/HabitDateInput.tsx
@@ -11,6 +11,8 @@ import { format } from "date-fns";
 
 import ThemeContext from "@/contexts/ThemeContext";
 import { HabitDateType } from "@/features/habit/types/habitTypes";
+import { formatProtocolFrequencySummary } from "@/features/habit/utils/protocolDisplay";
+import { fromApiDate, toApiDate } from "@/utils/date-time";
 import styling from "./style/HabitInputStyle";
 import StartDateModal from "./Modal/StartDateModal";
 
@@ -18,12 +20,14 @@ interface HabitDateInputProps {
   onSelect: (value: any) => void;
   isEditMode?: HabitDateType;
   style?: StyleProp<ViewStyle>;
+  label?: string;
 }
 
 const HabitDateInput: React.FC<HabitDateInputProps> = ({
   onSelect,
   style,
   isEditMode,
+  label = "Start your journey",
 }) => {
   const { spacing, newTheme } = useContext(ThemeContext);
   const styles = styling(newTheme, spacing);
@@ -34,42 +38,46 @@ const HabitDateInput: React.FC<HabitDateInputProps> = ({
 
   const [showStartTaskModal, setShowStartTaskModal] = useState(false);
 
+  const asDate = (value?: Date | string | null) => {
+    if (!value) return undefined;
+    return value instanceof Date ? value : fromApiDate(value);
+  };
+
   // ✅ keep local state in sync when parent sends edit data
   useEffect(() => {
     if (isEditMode) {
       setHabitDate({
         ...isEditMode,
-        start_date: isEditMode.start_date
-          ? new Date(isEditMode.start_date)
-          : new Date(),
-        end_date: isEditMode.end_date
-          ? new Date(isEditMode.end_date)
-          : undefined,
+        start_date: asDate(isEditMode.start_date) ?? new Date(),
+        end_date: asDate(isEditMode.end_date),
       });
     }
   }, [isEditMode]);
 
   const userDisplay = useMemo(() => {
-    const start = habitDate.start_date
-      ? new Date(habitDate.start_date)
-      : new Date();
-    const end = habitDate.end_date ? new Date(habitDate.end_date) : undefined;
+    const start = asDate(habitDate.start_date) ?? new Date();
+    const end = asDate(habitDate.end_date);
 
     return end
       ? `${format(start, "dd-MM-yyyy")} - ${format(end, "dd-MM-yyyy")}`
       : `${format(start, "dd-MM-yyyy")}`;
   }, [habitDate]);
 
+  const recurrenceDisplay = useMemo(
+    () => formatProtocolFrequencySummary(habitDate),
+    [habitDate]
+  );
+
   const pushToParent = (hd: HabitDateType) => {
     const { start_date, end_date, ...rest } = hd;
 
     let result: any = end_date
       ? {
-          start_date: format(new Date(start_date), "yyyy-MM-dd"),
-          end_date: format(new Date(end_date), "yyyy-MM-dd"),
+          start_date: toApiDate(asDate(start_date) ?? new Date()),
+          end_date: toApiDate(asDate(end_date) ?? new Date()),
         }
       : {
-          start_date: format(new Date(start_date), "yyyy-MM-dd"),
+          start_date: toApiDate(asDate(start_date) ?? new Date()),
         };
 
     if (rest.frequency_type) {
@@ -104,11 +112,28 @@ const HabitDateInput: React.FC<HabitDateInputProps> = ({
             size={20}
             color={newTheme.textSecondary}
           />
-          <Text style={styles.rowLabel}>Start your journey</Text>
+          <Text style={styles.rowLabel}>{label}</Text>
         </View>
 
         <View style={styles.rowRight}>
-          <Text style={styles.rowValue}>{userDisplay}</Text>
+          <View style={styles.rowValueStack}>
+            <Text
+              style={styles.rowValue}
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            >
+              {userDisplay}
+            </Text>
+            {!!recurrenceDisplay && (
+              <Text
+                style={styles.rowValueSecondary}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {recurrenceDisplay}
+              </Text>
+            )}
+          </View>
           <Ionicons
             name="chevron-forward"
             size={18}

--- a/features/habit/components/create-habit/HabitDurationInput.tsx
+++ b/features/habit/components/create-habit/HabitDurationInput.tsx
@@ -1,9 +1,7 @@
 import {
   View,
   TouchableOpacity,
-  StyleSheet,
   Text,
-  Platform,
   StyleProp,
   ViewStyle,
 } from "react-native";
@@ -23,12 +21,20 @@ interface HabitDurationInputProps {
   onSelect: (value: any) => void;
   isEditMode?: Duration;
   style?: StyleProp<ViewStyle>;
+  label?: string;
+  compact?: boolean;
+  showLabel?: boolean;
+  showIcon?: boolean;
 }
 
 const HabitDurationInput: React.FC<HabitDurationInputProps> = ({
   onSelect,
   style,
   isEditMode,
+  label = "Rhythm",
+  compact = false,
+  showLabel = true,
+  showIcon = true,
 }) => {
   const [duration, setDuration] = useState<Duration>({ all_day: true });
 
@@ -37,25 +43,17 @@ const HabitDurationInput: React.FC<HabitDurationInputProps> = ({
   const { newTheme, spacing } = useContext(ThemeContext);
 
   const styles = styling(newTheme, spacing);
+  const showLeftContent = showLabel || showIcon;
+  const compactRow = compact || !showLeftContent;
 
   const handleSave = (selectedDuration: any) => {
-    console.log(selectedDuration, "selectedDuration");
     onSelect(toBackendDurationPayload(selectedDuration));
   };
 
-  // function to handle task duration
   const handleHabitDuration = (selectedDuration: any) => {
     setDuration(selectedDuration);
     handleSave(selectedDuration);
   };
-
-  useEffect(() => {
-    if (duration.all_day) {
-      onSelect({ all_day: true });
-    } else {
-      onSelect(toBackendDurationPayload(duration));
-    }
-  }, []);
 
   useEffect(() => {
     if (isEditMode) {
@@ -66,20 +64,28 @@ const HabitDurationInput: React.FC<HabitDurationInputProps> = ({
   return (
     <>
       <TouchableOpacity
-        style={[styles.rowItem, style]}
+        style={[
+          styles.rowItem,
+          compactRow && { alignSelf: "flex-start", justifyContent: "space-between" },
+          style,
+        ]}
         onPress={() => setShowDurationModal(true)}
       >
-        <View style={styles.rowLeft}>
-          <Ionicons
-            style={styles.iconLeft}
-            name="time-outline"
-            size={20}
-            color={newTheme.textSecondary}
-          />
-          <Text style={styles.rowLabel}>When it happens</Text>
-        </View>
+        {showLeftContent && (
+          <View style={styles.rowLeft}>
+            {showIcon && (
+              <Ionicons
+                style={styles.iconLeft}
+                name="time-outline"
+                size={20}
+                color={newTheme.textSecondary}
+              />
+            )}
+            {showLabel && <Text style={styles.rowLabel}>{label}</Text>}
+          </View>
+        )}
 
-        <View style={styles.rowRight}>
+        <View style={[styles.rowRight, compactRow && { maxWidth: "100%" }]}>
           <Text style={styles.rowValue} numberOfLines={1} ellipsizeMode="tail">
             {formatDurationDisplay(duration, { allDayLabel: "All Day" })}
           </Text>
@@ -97,6 +103,8 @@ const HabitDurationInput: React.FC<HabitDurationInputProps> = ({
         onClose={() => setShowDurationModal(false)}
         isEditMode={duration}
         onSave={handleHabitDuration}
+        title="Rhythm"
+        subtitle="Choose whether this habit runs all day or within a focused window."
       />
     </>
   );

--- a/features/habit/components/create-habit/HabitReminderInput.tsx
+++ b/features/habit/components/create-habit/HabitReminderInput.tsx
@@ -33,6 +33,8 @@ interface HabitReminderInputProps {
   onSelect: (value: any) => void;
   style?: StyleProp<ViewStyle>;
   isEditMode?: EditData;
+  label?: string;
+  fallbackLabel?: string;
 }
 
 const HabitReminderInput: React.FC<HabitReminderInputProps> = ({
@@ -40,6 +42,8 @@ const HabitReminderInput: React.FC<HabitReminderInputProps> = ({
   isAllDayEnabled,
   isEditMode,
   style,
+  label = "Your daily nudge",
+  fallbackLabel = "Select the preset",
 }) => {
   const { newTheme, spacing } = useContext(ThemeContext);
   const styles = styling(newTheme, spacing);
@@ -72,12 +76,10 @@ const HabitReminderInput: React.FC<HabitReminderInputProps> = ({
     }
   }, [isEditMode, onSelect]);
 
-  console.log("HabitReminderInput rendered", isAllDayEnabled);
-
   // ✅ consistent UI time across app
   const userDisplay = useMemo(() => {
-    return formatReminderDisplay(reminderAt, { fallback: "Select the preset" });
-  }, [reminderAt]);
+    return formatReminderDisplay(reminderAt, { fallback: fallbackLabel });
+  }, [fallbackLabel, reminderAt]);
 
   const handleHabitReminder = (next: ReminderAt) => {
     setReminderAt(next);
@@ -114,7 +116,7 @@ const HabitReminderInput: React.FC<HabitReminderInputProps> = ({
             size={20}
             color={newTheme.textSecondary}
           />
-          <Text style={styles.rowLabel}>Your daily nudge</Text>
+          <Text style={styles.rowLabel}>{label}</Text>
         </View>
 
         <View style={styles.rowRight}>

--- a/features/habit/components/create-habit/HabitTagsInput.tsx
+++ b/features/habit/components/create-habit/HabitTagsInput.tsx
@@ -1,10 +1,8 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import {
   View,
   Text,
-  StyleSheet,
   TouchableOpacity,
-  Modal,
   StyleProp,
   ViewStyle,
 } from "react-native";
@@ -27,14 +25,22 @@ export type selectedTag = {
 interface HabitTagsInputProps {
   onSelect: (selectedTag: selectedTag) => void;
   style?: StyleProp<ViewStyle>;
+  label?: string;
+  showIcon?: boolean;
 }
 
-const HabitTagsInput: React.FC<HabitTagsInputProps> = ({ onSelect, style }) => {
+const HabitTagsInput: React.FC<HabitTagsInputProps> = ({
+  onSelect,
+  style,
+  label = "Add a vibe",
+  showIcon = true,
+}) => {
   const [tagsList, setTagsList] = useState<HabitTag[]>([]);
 
   const [selectedTag, setSelectedTag] = useState<HabitTag[]>([]);
 
   const [showHabitTagsModal, setShowHabitTagsModal] = useState(false);
+  const onSelectRef = useRef(onSelect);
 
   const { spacing, newTheme } = useContext(ThemeContext);
   const styles = styling(newTheme, spacing);
@@ -56,11 +62,7 @@ const HabitTagsInput: React.FC<HabitTagsInputProps> = ({ onSelect, style }) => {
 
   // Handle removing tags
   const handleRemoveTag = (index: number) => {
-    const res = selectedTag;
-    const updatedTags = [...res];
-    updatedTags.splice(index, 1);
-    // TODO
-    setSelectedTag(updatedTags);
+    setSelectedTag((prevTags) => prevTags.filter((_, i) => i !== index));
   };
 
   const handleOnSelect = (selectedHabitTag: any, newTag?: string) => {
@@ -89,10 +91,12 @@ const HabitTagsInput: React.FC<HabitTagsInputProps> = ({ onSelect, style }) => {
   };
 
   useEffect(() => {
-    if (selectedTag.length) {
-      const result = constructTagObject(selectedTag);
-      onSelect(result);
-    }
+    onSelectRef.current = onSelect;
+  }, [onSelect]);
+
+  useEffect(() => {
+    const result = constructTagObject(selectedTag);
+    onSelectRef.current(result);
   }, [selectedTag]);
 
   const onCloseModalClick = () => {
@@ -107,13 +111,19 @@ const HabitTagsInput: React.FC<HabitTagsInputProps> = ({ onSelect, style }) => {
           onPress={() => setShowHabitTagsModal(true)}
         >
           <View style={styles.rowLeft}>
-            <Ionicons
-              style={styles.iconLeft}
-              name="pricetags-outline"
-              size={20}
-              color={newTheme.textSecondary}
-            />
-            <Text style={styles.rowLabel}>Add a vibe</Text>
+            {showIcon && (
+              <Ionicons
+                style={styles.iconLeft}
+                name="pricetags-outline"
+                size={20}
+                color={newTheme.textSecondary}
+              />
+            )}
+            <Text
+              style={[styles.rowLabel, !showIcon && styles.rowLabelNoIcon]}
+            >
+              {label}
+            </Text>
           </View>
 
           <View style={styles.rowRight}>

--- a/features/habit/components/create-habit/Modal/DurationModal.tsx
+++ b/features/habit/components/create-habit/Modal/DurationModal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
 import {
   View,
   Modal,
@@ -8,69 +8,81 @@ import {
   KeyboardAvoidingView,
   SafeAreaView,
   Text,
+  ScrollView,
+  TouchableWithoutFeedback,
 } from "react-native";
-import DateTimePicker, {
-  DateTimePickerEvent,
-} from "@react-native-community/datetimepicker";
-import { Ionicons } from "@expo/vector-icons";
 import ThemeContext from "@/contexts/ThemeContext";
+import ModalHeader from "@/components/ui/modal/ModalHeader";
 import { StyledButton } from "@/components/ui/StyledButton";
 import StyledSwitch from "@/components/ui/theme-components/StyledSwitch";
 import TimeInput from "@/components/ui/picker/TimeInput";
+import { Duration } from "@/features/habit/types/habitTypes";
 
-export type Duration = {
-  all_day?: boolean;
-  start_time?: Date;
-  end_time?: Date;
+type DurationPreset = {
+  id: "morning" | "evening" | "work";
+  label: string;
+  start: { h: number; m: number };
+  end?: { h: number; m: number } | null;
 };
+
+const PRESETS: DurationPreset[] = [
+  {
+    id: "morning",
+    label: "Morning",
+    start: { h: 7, m: 0 },
+    end: null,
+  },
+  {
+    id: "evening",
+    label: "Evening",
+    start: { h: 19, m: 0 },
+    end: null,
+  },
+  {
+    id: "work",
+    label: "Work",
+    start: { h: 9, m: 0 },
+    end: { h: 17, m: 0 },
+  },
+];
 
 interface DurationModalProps {
   visible: boolean;
   onClose: () => void;
   onSave: (duration: Duration) => void;
   isEditMode?: Duration;
+  title?: string;
+  subtitle?: string;
 }
 
-const PRESETS = [
-  {
-    id: "morning",
-    label: "Morning (7:00 AM)",
-    start: { h: 7, m: 0 },
-    end: null,
-  },
-  {
-    id: "evening",
-    label: "Evening (7:00 PM)",
-    start: { h: 19, m: 0 },
-    end: null,
-  },
-  {
-    id: "work",
-    label: "Work (9:00 AM — 5:00 PM)",
-    start: { h: 9, m: 0 },
-    end: { h: 17, m: 0 },
-  },
-];
+const sameClockTime = (date: Date, hours: number, minutes: number) =>
+  date.getHours() === hours && date.getMinutes() === minutes;
 
-export default function HabitDurationModal({
+export default function DurationModal({
   visible,
   onClose,
   onSave,
   isEditMode,
+  title = "Rhythm",
+  subtitle = "Choose whether this habit runs all day or within a focused window.",
 }: DurationModalProps) {
-  const { newTheme } = useContext(ThemeContext);
-  const styles = styling(newTheme);
+  const { newTheme, spacing, svaTypography, typography } =
+    useContext(ThemeContext);
+  const bodyTextStyle = svaTypography?.textStyle?.body ?? typography.body;
+  const styles = useMemo(
+    () => styling(newTheme, spacing, bodyTextStyle, svaTypography),
+    [newTheme, spacing, bodyTextStyle, svaTypography]
+  );
 
-  // state
   const [allDayEnabled, setAllDayEnabled] = useState<boolean>(true);
   const [mode, setMode] = useState<"point" | "period">("point");
   const [start, setStart] = useState<Date>(new Date());
   const [end, setEnd] = useState<Date>(new Date());
-  const [showStartPicker, setShowStartPicker] = useState(false);
-  const [showEndPicker, setShowEndPicker] = useState(false);
   const [error, setError] = useState<string>("");
 
   useEffect(() => {
+    if (!visible) return;
+
     if (isEditMode) {
       if (isEditMode.all_day) {
         setAllDayEnabled(true);
@@ -91,407 +103,456 @@ export default function HabitDurationModal({
       const now = new Date();
       now.setMinutes(0, 0, 0);
       setStart(now);
-      const oneHour = new Date(now.getTime() + 60 * 60 * 1000);
-      setEnd(oneHour);
+      setEnd(new Date(now.getTime() + 60 * 60 * 1000));
     }
+
+    setError("");
   }, [isEditMode, visible]);
 
-  const applyPreset = (p: (typeof PRESETS)[number]) => {
-    // build Date objects for today with preset hours
-    const today = new Date();
-    const s = new Date(today);
-    s.setHours(p.start.h, p.start.m, 0, 0);
-    setStart(s);
+  const handleClose = () => {
+    setError("");
+    onClose();
+  };
 
-    if (p.end) {
-      const e = new Date(today);
-      e.setHours(p.end.h, p.end.m, 0, 0);
-      setEnd(e);
+  const applyPreset = (preset: DurationPreset) => {
+    const today = new Date();
+    const nextStart = new Date(today);
+    nextStart.setHours(preset.start.h, preset.start.m, 0, 0);
+    setStart(nextStart);
+
+    if (preset.end) {
+      const nextEnd = new Date(today);
+      nextEnd.setHours(preset.end.h, preset.end.m, 0, 0);
+      setEnd(nextEnd);
       setMode("period");
       setAllDayEnabled(false);
     } else {
       setMode("point");
       setAllDayEnabled(false);
     }
+
     setError("");
-  };
-
-  const onChangeStart = (
-    event: DateTimePickerEvent,
-    selected?: Date | undefined
-  ) => {
-    setShowStartPicker(Platform.OS === "ios");
-    if (selected) {
-      setStart(selected);
-      setError("");
-      // If period, ensure end is later; if not, push end one hour forward
-      if (mode === "period" && selected >= end) {
-        const next = new Date(selected.getTime() + 60 * 60 * 1000);
-        setEnd(next);
-      }
-    }
-  };
-
-  const onChangeEnd = (
-    event: DateTimePickerEvent,
-    selected?: Date | undefined
-  ) => {
-    setShowEndPicker(Platform.OS === "ios");
-    if (selected) {
-      setEnd(selected);
-      if (selected <= start) {
-        setError("End time must be after start time.");
-      } else {
-        setError("");
-      }
-    }
   };
 
   const handleSave = () => {
     if (allDayEnabled) {
       onSave({ all_day: true });
-      onClose();
+      handleClose();
       return;
     }
 
     if (mode === "point") {
       onSave({ start_time: start });
-      onClose();
+      handleClose();
       return;
     }
 
-    // period
     if (end <= start) {
       setError("End time must be after start time.");
       return;
     }
+
     onSave({ start_time: start, end_time: end });
-    onClose();
+    handleClose();
+  };
+
+  const isPresetSelected = (preset: DurationPreset) => {
+    if (allDayEnabled) return false;
+
+    if (preset.id === "morning") {
+      return mode === "point" && sameClockTime(start, 7, 0);
+    }
+
+    if (preset.id === "evening") {
+      return mode === "point" && sameClockTime(start, 19, 0);
+    }
+
+    return (
+      mode === "period" &&
+      sameClockTime(start, 9, 0) &&
+      sameClockTime(end, 17, 0)
+    );
   };
 
   return (
     <Modal
       visible={visible}
       transparent
-      animationType="none"
+      animationType="slide"
       statusBarTranslucent
-      onRequestClose={onClose}
+      onRequestClose={handleClose}
     >
-      <View style={styles.overlay} />
+      <View style={styles.overlay}>
+        <TouchableWithoutFeedback onPress={handleClose}>
+          <View style={styles.backdrop} />
+        </TouchableWithoutFeedback>
 
-      <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-        style={styles.centering}
-      >
-        <SafeAreaView style={{ width: "100%", paddingHorizontal: 20 }}>
-          <View
-            style={[
-              styles.card,
-              {
-                backgroundColor: newTheme.surface,
-                borderColor: newTheme.divider,
-              },
-            ]}
-          >
-            {/* header */}
-            <View style={styles.header}>
-              <Text style={[styles.title, { color: newTheme.textPrimary }]}>
-                Habit Duration
-              </Text>
-              <TouchableOpacity onPress={onClose} accessibilityLabel="Close">
-                <Ionicons name="close" size={22} color={newTheme.textPrimary} />
-              </TouchableOpacity>
-            </View>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+          style={styles.centering}
+        >
+          <SafeAreaView style={styles.safe}>
+            <View style={styles.sheet}>
+              <View style={styles.sheetHandle} />
 
-            {/* All day toggle + short help */}
-            <View style={styles.rowBetween}>
-              <View>
-                <Text style={[styles.label, { color: newTheme.textSecondary }]}>
-                  All day
-                </Text>
-                <Text style={[styles.help, { color: newTheme.textSecondary }]}>
-                  Quick: choose a preset or set specific time
-                </Text>
-              </View>
-
-              <StyledSwitch
-                value={allDayEnabled}
-                onValueChange={() => {
-                  setAllDayEnabled((s) => !s);
-                }}
-                size="medium"
+              <ModalHeader
+                title={title}
+                subtitle={subtitle}
+                onClose={handleClose}
+                style={styles.modalHeaderCompact}
+                titleStyle={styles.headerTitle}
+                subtitleStyle={styles.headerSubtitle}
               />
-            </View>
 
-            {/* Presets */}
-            {!allDayEnabled && (
-              <View style={{ marginTop: 12, marginBottom: 6 }}>
-                <View style={styles.presetsRow}>
-                  {PRESETS.map((p) => (
-                    <TouchableOpacity
-                      key={p.id}
-                      onPress={() => applyPreset(p)}
-                      style={[
-                        styles.presetButton,
-                        { backgroundColor: newTheme.background },
-                      ]}
-                    >
-                      <Text style={{ color: newTheme.textPrimary }}>
-                        {p.label}
+              <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={styles.content}
+                keyboardShouldPersistTaps="handled"
+              >
+                <View style={styles.section}>
+                  <View style={styles.rowBetween}>
+                    <View style={styles.sectionCopy}>
+                      <Text style={styles.sectionLabel}>All day</Text>
+                      <Text style={styles.sectionHint}>
+                        Keep it continuous or define a focused window.
                       </Text>
-                    </TouchableOpacity>
-                  ))}
+                    </View>
+
+                    <StyledSwitch
+                      value={allDayEnabled}
+                      onValueChange={() => {
+                        setAllDayEnabled((current) => {
+                          const next = !current;
+                          if (!next) setError("");
+                          return next;
+                        });
+                      }}
+                      size="medium"
+                    />
+                  </View>
                 </View>
-              </View>
-            )}
 
-            {/* Mode: Point / Period */}
-            {!allDayEnabled && (
-              <View style={[styles.row, { marginTop: 6 }]}>
-                <TouchableOpacity
-                  style={styles.radio}
-                  onPress={() => setMode("point")}
-                >
-                  <Ionicons
-                    name={
-                      mode === "point" ? "radio-button-on" : "radio-button-off"
-                    }
-                    size={18}
-                    color={
-                      mode === "point"
-                        ? newTheme.accent
-                        : newTheme.textSecondary
-                    }
-                  />
-                  <Text
-                    style={[
-                      styles.radioLabel,
-                      {
-                        color:
-                          mode === "point"
-                            ? newTheme.textPrimary
-                            : newTheme.textSecondary,
-                      },
-                    ]}
-                  >
-                    Point time
-                  </Text>
-                </TouchableOpacity>
+                {!allDayEnabled ? (
+                  <>
+                    <View style={styles.section}>
+                      <Text style={styles.sectionLabel}>Quick windows</Text>
+                      <Text style={styles.sectionHint}>
+                        Tap a preset or set your own span.
+                      </Text>
 
-                <TouchableOpacity
-                  style={styles.radio}
-                  onPress={() => setMode("period")}
-                >
-                  <Ionicons
-                    name={
-                      mode === "period" ? "radio-button-on" : "radio-button-off"
-                    }
-                    size={18}
-                    color={
-                      mode === "period"
-                        ? newTheme.accent
-                        : newTheme.textSecondary
-                    }
-                  />
-                  <Text
-                    style={[
-                      styles.radioLabel,
-                      {
-                        color:
-                          mode === "period"
-                            ? newTheme.textPrimary
-                            : newTheme.textSecondary,
-                      },
-                    ]}
-                  >
-                    Time period
-                  </Text>
-                </TouchableOpacity>
-              </View>
-            )}
+                      <View style={styles.pillsRow}>
+                        {PRESETS.map((preset) => {
+                          const selected = isPresetSelected(preset);
+                          return (
+                            <TouchableOpacity
+                              key={preset.id}
+                              onPress={() => applyPreset(preset)}
+                              style={[
+                                styles.pill,
+                                selected && styles.pillSelected,
+                              ]}
+                              activeOpacity={0.9}
+                            >
+                              <Text
+                                style={[
+                                  styles.pillText,
+                                  selected && styles.pillTextSelected,
+                                ]}
+                                numberOfLines={1}
+                              >
+                                {preset.label}
+                              </Text>
+                            </TouchableOpacity>
+                          );
+                        })}
+                      </View>
+                    </View>
 
-            {/* Time pickers */}
-            {!allDayEnabled && (
-              <View style={{ marginTop: 12 }}>
-                <TimeInput
-                  label="Start"
-                  value={start}
-                  onChange={(next) => {
-                    setStart(next);
-                    setError("");
-                    if (mode === "period" && next >= end) {
-                      setEnd(new Date(next.getTime() + 60 * 60 * 1000));
-                    }
-                  }}
-                  title="Start time"
+                    <View style={styles.section}>
+                      <Text style={styles.sectionLabel}>Window mode</Text>
+                      <Text style={styles.sectionHint}>
+                        Choose a point in time or a time span.
+                      </Text>
+
+                      <View style={styles.pillsRow}>
+                        <TouchableOpacity
+                          style={[
+                            styles.pill,
+                            mode === "point" && styles.pillSelected,
+                          ]}
+                          onPress={() => {
+                            setMode("point");
+                            setError("");
+                          }}
+                          activeOpacity={0.9}
+                        >
+                          <Text
+                            style={[
+                              styles.pillText,
+                              mode === "point" && styles.pillTextSelected,
+                            ]}
+                            numberOfLines={1}
+                          >
+                            Point time
+                          </Text>
+                        </TouchableOpacity>
+
+                        <TouchableOpacity
+                          style={[
+                            styles.pill,
+                            mode === "period" && styles.pillSelected,
+                          ]}
+                          onPress={() => {
+                            setMode("period");
+                            setAllDayEnabled(false);
+                            setError("");
+                          }}
+                          activeOpacity={0.9}
+                        >
+                          <Text
+                            style={[
+                              styles.pillText,
+                              mode === "period" && styles.pillTextSelected,
+                            ]}
+                            numberOfLines={1}
+                          >
+                            Time period
+                          </Text>
+                        </TouchableOpacity>
+                      </View>
+
+                      <View style={{ marginTop: 14 }}>
+                        <TimeInput
+                          label="Start"
+                          value={start}
+                          onChange={(next) => {
+                            setStart(next);
+                            setError("");
+                            if (mode === "period" && next >= end) {
+                              setEnd(new Date(next.getTime() + 60 * 60 * 1000));
+                            }
+                          }}
+                          title="Start time"
+                        />
+
+                        {mode === "period" ? (
+                          <View style={{ marginTop: 12 }}>
+                            <TimeInput
+                              label="End"
+                              value={end}
+                              onChange={(next) => {
+                                setEnd(next);
+                                if (next <= start) {
+                                  setError("End time must be after start time.");
+                                } else {
+                                  setError("");
+                                }
+                              }}
+                              title="End time"
+                            />
+                          </View>
+                        ) : null}
+                      </View>
+                    </View>
+                  </>
+                ) : null}
+
+                {error ? (
+                  <View style={styles.errorBox}>
+                    <Text style={styles.error}>{error}</Text>
+                  </View>
+                ) : null}
+              </ScrollView>
+
+              <View style={styles.footer}>
+                <StyledButton
+                  label="Cancel"
+                  onPress={handleClose}
+                  variant="outline"
+                  style={styles.footerBtn}
                 />
-
-                {mode === "period" && (
-                  <TimeInput
-                    label="End"
-                    value={end}
-                    onChange={(next) => {
-                      setEnd(next);
-                      if (next <= start)
-                        setError("End time must be after start time.");
-                      else setError("");
-                    }}
-                    title="End time"
-                  />
-                )}
+                <StyledButton
+                  label="Save"
+                  onPress={handleSave}
+                  disabled={!allDayEnabled && mode === "period" && end <= start}
+                  style={styles.footerBtn}
+                />
               </View>
-            )}
-
-            {error ? (
-              <Text style={[styles.error, { color: newTheme.error }]}>
-                {error}
-              </Text>
-            ) : null}
-
-            {/* actions */}
-            <View style={styles.actionsRow}>
-              <StyledButton
-                label="Cancel"
-                onPress={onClose}
-                variant="outline"
-                style={{ minWidth: 140 }}
-              />
-
-              <StyledButton
-                label="Save"
-                onPress={() => handleSave()}
-                disabled={!allDayEnabled && mode === "period" && end <= start}
-                style={{ minWidth: 140 }}
-              />
             </View>
-          </View>
-        </SafeAreaView>
-      </KeyboardAvoidingView>
-
-      {/* native datetime pickers */}
-      {/* {showStartPicker && (
-        <View style={styles.pickerContainer}>
-          <DateTimePicker
-            value={start}
-            mode="time"
-            display={Platform.OS === "ios" ? "spinner" : "default"}
-            onChange={onChangeStart}
-            is24Hour={false}
-          />
-          <View style={styles.pickerButtons}>
-            <TouchableOpacity
-              onPress={() => setShowStartPicker(false)}
-              style={styles.pickerBtn}
-            >
-              <Text style={styles.pickerBtnText}>Done</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-      )} */}
-      {/* {showEndPicker && (
-        <View style={styles.pickerContainer}>
-          <DateTimePicker
-            value={end}
-            mode="time"
-            display={Platform.OS === "ios" ? "spinner" : "default"}
-            onChange={onChangeEnd}
-            is24Hour={false}
-          />
-          <View style={styles.pickerButtons}>
-            <TouchableOpacity
-              onPress={() => setShowEndPicker(false)}
-              style={styles.pickerBtn}
-            >
-              <Text style={styles.pickerBtnText}>Done</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-      )} */}
+          </SafeAreaView>
+        </KeyboardAvoidingView>
+      </View>
     </Modal>
   );
 }
 
-/* ---------- styles ---------- */
-const styling = (newTheme: any) =>
+const styling = (t: any, spacing: any, bodyTextStyle: any, svaTypography: any) =>
   StyleSheet.create({
     overlay: {
+      flex: 1,
+      justifyContent: "flex-end",
+    },
+    backdrop: {
       ...StyleSheet.absoluteFillObject,
-      backgroundColor: "rgba(0,0,0,0.45)",
+      backgroundColor: t.overlayStrong ?? "rgba(12,14,11,0.62)",
     },
     centering: {
       flex: 1,
-      justifyContent: "center",
-      paddingHorizontal: 20,
+      justifyContent: "flex-end",
     },
-    card: {
-      borderRadius: 14,
-      padding: 18,
+    safe: {
+      width: "100%",
+      paddingHorizontal: 14,
+      paddingBottom: 12,
+    },
+    sheet: {
+      width: "100%",
+      maxWidth: 720,
+      alignSelf: "center",
+      maxHeight: "94%",
+      overflow: "hidden",
+      backgroundColor: t.surfaceMuted ?? t.surface,
+      borderTopLeftRadius: 36,
+      borderTopRightRadius: 36,
       borderWidth: 1,
-      // subtle shadow
+      borderColor: t.borderMuted ?? t.border,
       ...Platform.select({
         ios: {
           shadowColor: "#000",
-          shadowOpacity: 0.35,
-          shadowOffset: { width: 0, height: 8 },
-          shadowRadius: 20,
+          shadowOpacity: 0.24,
+          shadowOffset: { width: 0, height: 16 },
+          shadowRadius: 30,
         },
-        android: { elevation: 10 },
+        android: { elevation: 16 },
       }),
     },
-    header: {
-      flexDirection: "row",
-      justifyContent: "space-between",
-      alignItems: "center",
-      marginBottom: 25,
+    sheetHandle: {
+      alignSelf: "center",
+      width: 54,
+      height: 5,
+      borderRadius: 999,
+      backgroundColor: t.borderMuted ?? t.border,
+      marginTop: 10,
+      marginBottom: 10,
     },
-    title: { fontSize: 20, fontWeight: "700" },
-    label: { fontSize: 14, fontWeight: "600" },
-    help: { fontSize: 12, marginTop: 4 },
+    modalHeaderCompact: {
+      paddingHorizontal: spacing.xl,
+      paddingTop: 0,
+      paddingBottom: 8,
+    },
+    headerTitle: {
+      ...(svaTypography?.textStyle?.displayMedium ?? {}),
+      fontSize: 28,
+      lineHeight: 32,
+      color: t.textPrimary,
+      fontStyle: "normal",
+    },
+    headerSubtitle: {
+      ...bodyTextStyle,
+      fontSize: 13,
+      lineHeight: 18,
+      color: t.textSecondary,
+    },
+    content: {
+      paddingHorizontal: spacing.xl,
+      paddingBottom: spacing.lg,
+    },
+    section: {
+      padding: spacing.lg,
+      borderRadius: 24,
+      backgroundColor: t.surface ?? t.background,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: t.borderMuted ?? t.border,
+      marginBottom: spacing.lg,
+      ...Platform.select({
+        ios: {
+          shadowColor: "#000",
+          shadowOpacity: 0.12,
+          shadowOffset: { width: 0, height: 8 },
+          shadowRadius: 18,
+        },
+        android: { elevation: 3 },
+      }),
+    },
+    sectionCopy: {
+      flex: 1,
+      paddingRight: 12,
+    },
+    sectionLabel: {
+      fontSize: 11,
+      fontWeight: "700",
+      color: t.textSecondary,
+      marginBottom: 8,
+      letterSpacing: 1.4,
+      textTransform: "uppercase",
+    },
+    sectionHint: {
+      marginTop: 4,
+      fontSize: 12,
+      color: t.textSecondary,
+      lineHeight: 16,
+    },
     rowBetween: {
       flexDirection: "row",
       justifyContent: "space-between",
       alignItems: "center",
     },
-    presetsRow: { flexDirection: "row", gap: 10, flexWrap: "wrap" } as any,
-    presetButton: {
-      paddingVertical: 8,
-      paddingHorizontal: 12,
-      borderRadius: 20,
-      marginRight: 8,
-    },
-    pickerContainer: {
-      backgroundColor: newTheme.surface,
-      borderTopLeftRadius: 12,
-      borderTopRightRadius: 12,
-      paddingBottom: Platform.OS === "ios" ? 32 : 12,
-      paddingTop: 8,
-    },
-    row: { flexDirection: "row", gap: 18, marginTop: 8 },
-    radio: { flexDirection: "row", alignItems: "center", gap: 8 },
-    radioLabel: { fontSize: 15 },
-    selector: {
-      borderWidth: 1,
-      borderRadius: 10,
-      paddingVertical: 12,
-      paddingHorizontal: 14,
-      marginTop: 6,
+    pillsRow: {
       flexDirection: "row",
-      justifyContent: "space-between",
+      flexWrap: "wrap",
+      gap: 8,
+      marginTop: 12,
+    } as any,
+    pill: {
+      flexGrow: 1,
+      flexBasis: 0,
+      minHeight: 42,
+      paddingHorizontal: 16,
+      borderRadius: 999,
       alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: t.cardRaised ?? t.surfaceMuted ?? t.background,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: t.borderMuted ?? t.border,
     },
-    fieldLabel: { fontSize: 13, fontWeight: "600", marginBottom: 6 },
-    error: { marginTop: 8, fontSize: 13 },
-    actionsRow: {
+    pillSelected: {
+      backgroundColor: "rgba(163,190,140,0.14)",
+      borderColor: "rgba(163,190,140,0.32)",
+    },
+    pillText: {
+      color: t.textSecondary,
+      fontWeight: "700",
+      fontSize: 13,
+      letterSpacing: 0.2,
+      textAlign: "center",
+    },
+    pillTextSelected: {
+      color: t.accent,
+      fontWeight: "800",
+    },
+    errorBox: {
+      marginTop: 4,
+      borderRadius: 18,
+      paddingVertical: 10,
+      paddingHorizontal: 14,
+      backgroundColor: "rgba(255, 99, 99, 0.08)",
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: "rgba(255, 99, 99, 0.22)",
+    },
+    error: {
+      color: t.error ?? "#FF6B6B",
+      fontSize: 13,
+      lineHeight: 18,
+      fontWeight: "600",
+    },
+    footer: {
       flexDirection: "row",
-      justifyContent: "space-between",
-      marginTop: 18,
+      gap: 12,
+      paddingHorizontal: spacing.xl,
+      paddingBottom: spacing.xl,
+      paddingTop: 2,
+    } as any,
+    footerBtn: {
+      flex: 1,
     },
-    pickerButtons: {
-      flexDirection: "row",
-      justifyContent: "flex-end",
-      paddingHorizontal: 12,
-      paddingVertical: 8,
-    },
-    pickerBtn: { paddingVertical: 10, paddingHorizontal: 18 },
-    pickerBtnText: { color: newTheme.accent, fontWeight: "700", fontSize: 16 },
   });

--- a/features/habit/components/create-habit/Modal/HabitTagsModal.tsx
+++ b/features/habit/components/create-habit/Modal/HabitTagsModal.tsx
@@ -1,22 +1,21 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
 import {
   View,
   Text,
   StyleSheet,
   TouchableOpacity,
   Modal,
-  TextInput,
+  TouchableWithoutFeedback,
+  FlatList,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 
 import ThemeContext from "@/contexts/ThemeContext";
-import { findIdBName, addObjectAtEnd } from "@/utils/helper";
+import { addObjectAtEnd } from "@/utils/helper";
 import { HabitTag } from "@/features/habit/types/habitTypes";
-import { selectedTag } from "../HabitTagsInput";
 import InputField from "@/components/ui/theme-components/StyledInputOld";
+import ModalHeader from "@/components/ui/modal/ModalHeader";
 // import styling from "../style/HabitTagModalStyle";
-
-type ThemeKey = "basic" | "light" | "dark";
 
 interface TagsType {
   id: number;
@@ -29,6 +28,7 @@ interface TaskTagsModalProps {
   onClose: () => void;
   selectedTagData: any;
   onSelect: (tag?: any, newTag?: string) => void;
+  title?: string;
   //   existingTags: TagsType[];
   //   onAddNewTag: (tag: string, id: number) => void;
 }
@@ -39,6 +39,7 @@ const HabitTagsModal: React.FC<TaskTagsModalProps> = ({
   onClose,
   onSelect,
   selectedTagData,
+  title = "Select Tags",
   //   existingTags,
   //   onAddNewTag,
 }) => {
@@ -48,7 +49,7 @@ const HabitTagsModal: React.FC<TaskTagsModalProps> = ({
 
   const [selectedTag, setSelectedTag] = useState<TagsType[]>([]);
 
-  const [newTag, setNewTag] = useState<any>();
+  const [newTag, setNewTag] = useState("");
   const [error, setError] = useState("");
 
   const handleAddNew = () => {
@@ -60,7 +61,7 @@ const HabitTagsModal: React.FC<TaskTagsModalProps> = ({
       setError("Tag cannot exceed 20 characters.");
       return;
     }
-    if (selectedTag.includes(newTag.trim())) {
+    if (selectedTag.some((tag) => tag.name === newTag.trim())) {
       setError("Tag already exists.");
       return;
     }
@@ -69,11 +70,23 @@ const HabitTagsModal: React.FC<TaskTagsModalProps> = ({
     // setNewTag("");
     setIsAdding(false);
     setError("");
+    handleClose();
+  };
+
+  const handleClose = () => {
+    setIsAdding(false);
+    setNewTag("");
+    setError("");
     onClose();
   };
 
-  const { newTheme } = useContext(ThemeContext);
-  const styles = styling(newTheme);
+  const { newTheme, spacing, svaTypography, typography } =
+    useContext(ThemeContext);
+  const bodyTextStyle = svaTypography?.textStyle?.body ?? typography.body;
+  const styles = useMemo(
+    () => styling(newTheme, spacing, bodyTextStyle),
+    [newTheme, spacing, bodyTextStyle]
+  );
 
   useEffect(() => {
     const modifiedArray = addObjectAtEnd(habitTagList);
@@ -96,66 +109,83 @@ const HabitTagsModal: React.FC<TaskTagsModalProps> = ({
   };
 
   useEffect(() => {
-    if (selectedTagData.length) setSelectedTag(selectedTagData);
+    setSelectedTag(Array.isArray(selectedTagData) ? selectedTagData : []);
   }, [selectedTagData]);
-
-  // useEffect(() => {
-  //   if (selectedTag.length && newTag) {
-  //     onSelect(selectedTag, newTag);
-  //   }
-  // }, [newTag]);
 
   return (
     <Modal
       animationType="slide"
       transparent={true}
       visible={visible}
-      onRequestClose={() => {
-        setIsAdding(false);
-        setNewTag("");
-        setError("");
-        onClose();
-      }}
+      onRequestClose={handleClose}
     >
       <View style={styles.modalOverlay}>
-        <View style={styles.modalContainer}>
-          {/* Header with Title and Close Button */}
-          <View style={styles.header}>
-            <Text style={styles.title}>Select Task Tag</Text>
-            <TouchableOpacity
-              onPress={() => {
-                setIsAdding(false);
-                setNewTag("");
-                setError("");
-                onClose();
-              }}
-            >
-              <Ionicons name="close" size={24} color={newTheme.textPrimary} />
-            </TouchableOpacity>
-          </View>
+        <TouchableWithoutFeedback onPress={handleClose}>
+          <View style={styles.backdrop} />
+        </TouchableWithoutFeedback>
 
-          {/* List of Task Tags */}
-          <View style={styles.listContainer}>
-            {habitTagData.map((tag, index) => (
-              <TouchableOpacity
-                key={index}
-                style={styles.tagButton}
-                onPress={() => {
-                  if (tag.name === "Add New") {
-                    setIsAdding(true);
-                  } else {
-                    handleSaveClick(tag);
-                    onClose();
-                  }
-                }}
-              >
-                <Text style={styles.tagText}>{tag.name}</Text>
-                {tag.name === "Add New" && (
-                  <Ionicons name="chevron-forward" size={20} color="#888" />
-                )}
-              </TouchableOpacity>
-            ))}
-          </View>
+        <View style={styles.modalContainer}>
+          <ModalHeader
+            title={title}
+            onClose={handleClose}
+            style={styles.modalHeaderCompact}
+          />
+
+          <FlatList
+            data={habitTagData}
+            keyExtractor={(item) =>
+              item.name === "Add New"
+                ? "habit-tags-add-new"
+                : item.id.toString()
+            }
+            style={styles.listContainer}
+            showsVerticalScrollIndicator={false}
+            renderItem={({ item }) => {
+              const isSelected = selectedTag.some((tag) => tag.id === item.id);
+              const isAddNew = item.name === "Add New";
+
+              return (
+                <TouchableOpacity
+                  style={[
+                    styles.tagButton,
+                    isSelected && styles.tagButtonSelected,
+                  ]}
+                  onPress={() => {
+                    if (isAddNew) {
+                      setIsAdding(true);
+                    } else {
+                      handleSaveClick(item);
+                      handleClose();
+                    }
+                  }}
+                >
+                  <View style={styles.tagTextWrap}>
+                    <Text
+                      style={[
+                        styles.tagText,
+                        isSelected && styles.selectedTagText,
+                      ]}
+                    >
+                      {item.name}
+                    </Text>
+                    {!isAddNew && isSelected && (
+                      <Text style={styles.selectedHint}>Selected</Text>
+                    )}
+                  </View>
+
+                  {isAddNew ? (
+                    <Ionicons name="chevron-forward" size={20} color="#888" />
+                  ) : isSelected ? (
+                    <Ionicons
+                      name="checkmark"
+                      size={20}
+                      color={newTheme.accent}
+                    />
+                  ) : null}
+                </TouchableOpacity>
+              );
+            }}
+          />
 
           {/* Add New Tag Section */}
           {isAdding && (
@@ -163,7 +193,6 @@ const HabitTagsModal: React.FC<TaskTagsModalProps> = ({
               <InputField
                 label="New Tag"
                 value={newTag}
-                // maxLength={20}
                 onChangeText={(text) => {
                   setNewTag(text);
                   if (text.length <= 20) {
@@ -172,19 +201,6 @@ const HabitTagsModal: React.FC<TaskTagsModalProps> = ({
                 }}
                 placeholder="Add New Tag"
               />
-
-              {/* <FormInput
-                style={styles.input}
-                placeholder="Enter news tag"
-                value={newTag}
-                onChangeText={(text) => {
-                  setNewTag(text);
-                  if (text.length <= 20) {
-                    setError("");
-                  }
-                }}
-                maxLength={20}
-              /> */}
               {error ? <Text style={styles.errorText}>{error}</Text> : null}
               <TouchableOpacity style={styles.addButton} onPress={handleAddNew}>
                 <Text style={styles.addButtonText}>Add</Text>
@@ -199,49 +215,64 @@ const HabitTagsModal: React.FC<TaskTagsModalProps> = ({
 
 export default HabitTagsModal;
 
-const styling = (newTheme: any) =>
+const styling = (newTheme: any, spacing: any, bodyTextStyle: any) =>
   StyleSheet.create({
     modalOverlay: {
       flex: 1,
-      backgroundColor: "rgba(0,0,0,0.5)",
-      justifyContent: "center",
-      alignItems: "center",
+      justifyContent: "flex-end",
     },
     modalContainer: {
-      width: "85%",
-      backgroundColor: newTheme.surface,
-      borderRadius: 10,
-      padding: 20,
-      maxHeight: "85%",
+      width: "100%",
+      height: "75%",
+      backgroundColor: newTheme.surfaceMuted,
+      borderTopLeftRadius: 32,
+      borderTopRightRadius: 32,
+      padding: spacing.xl,
+      borderWidth: 1,
+      borderColor: newTheme.borderMuted,
     },
-    header: {
-      flexDirection: "row",
-      justifyContent: "space-between",
-      alignItems: "center",
-      marginBottom: 20,
+    backdrop: {
+      ...StyleSheet.absoluteFillObject,
+      backgroundColor: newTheme.overlayStrong,
     },
-    title: {
-      fontSize: 18,
-      fontWeight: "bold",
-      color: newTheme.textPrimary,
+    modalHeaderCompact: {
+      paddingHorizontal: 0,
+      paddingTop: 0,
+      paddingBottom: 12,
     },
     listContainer: {
-      // Optional: Add any additional styling if needed
+      flex: 1,
     },
     tagButton: {
       flexDirection: "row",
       justifyContent: "space-between",
       alignItems: "center",
-      paddingVertical: 12,
+      paddingVertical: spacing.md,
       borderBottomWidth: 1,
-      borderBottomColor: newTheme.divider,
+      borderBottomColor: newTheme.borderMuted,
+    },
+    tagButtonSelected: {
+      backgroundColor: "rgba(255,255,255,0.03)",
+    },
+    tagTextWrap: {
+      flex: 1,
+      paddingRight: spacing.md,
     },
     tagText: {
-      fontSize: 16,
+      ...bodyTextStyle,
+      color: newTheme.textSecondary,
+    },
+    selectedTagText: {
       color: newTheme.textPrimary,
+      fontWeight: "700",
+    },
+    selectedHint: {
+      marginTop: 2,
+      fontSize: 12,
+      color: newTheme.textSecondary,
     },
     addNewContainer: {
-      marginTop: 20,
+      marginTop: spacing.lg,
     },
     input: {
       borderWidth: 1,
@@ -252,10 +283,10 @@ const styling = (newTheme: any) =>
       fontSize: 16,
     },
     addButton: {
-      marginTop: 10,
+      marginTop: spacing.md,
       backgroundColor: newTheme.accent,
       paddingVertical: 12,
-      borderRadius: 5,
+      borderRadius: 12,
       alignItems: "center",
     },
     addButtonText: {

--- a/features/habit/components/create-habit/Modal/StartDateModal.tsx
+++ b/features/habit/components/create-habit/Modal/StartDateModal.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useMemo, useState } from "react";
-import { addDays, differenceInDays } from "date-fns";
+import { addDays } from "date-fns";
 import {
   View,
   Modal,
@@ -13,19 +13,18 @@ import {
   Text,
   TouchableWithoutFeedback,
 } from "react-native";
-import { Ionicons } from "@expo/vector-icons";
 
 import ThemeContext from "@/contexts/ThemeContext";
+import ModalHeader from "@/components/ui/modal/ModalHeader";
 import { StyledButton } from "@/components/ui/StyledButton";
 import StyledSwitch from "@/components/ui/theme-components/StyledSwitch";
 import { HabitDateType } from "@/features/habit/types/habitTypes";
+import { fromApiDate } from "@/utils/date-time";
 
 // ✅ Nimbus-style date input (should open DatePickerSheet like TimeInput opens TimePickerSheet)
 import DateInput from "@/components/ui/picker/DateInput";
 
 type UIFreq = "Daily" | "Weekly" | "Monthly" | "";
-type BackendFreq = "daily" | "weekly" | "monthly" | "";
-
 const toUIFreq = (f?: string | null): UIFreq => {
   if (!f) return "";
   const v = f.toLowerCase();
@@ -56,6 +55,8 @@ interface HabitDateModalProps {
   onClose: () => void;
   onSave: (habitDate: HabitDateType) => void;
   isEditMode?: HabitDateType | null;
+  title?: string;
+  subtitle?: string;
 }
 
 export default function StartDateModal({
@@ -63,9 +64,16 @@ export default function StartDateModal({
   onClose,
   onSave,
   isEditMode,
+  title = "Start date",
+  subtitle = "Choose when this habit begins — and optionally repeats.",
 }: HabitDateModalProps) {
-  const { newTheme } = useContext(ThemeContext);
-  const styles = useMemo(() => styling(newTheme), [newTheme]);
+  const { newTheme, spacing, svaTypography, typography } =
+    useContext(ThemeContext);
+  const bodyTextStyle = svaTypography?.textStyle?.body ?? typography.body;
+  const styles = useMemo(
+    () => styling(newTheme, spacing, bodyTextStyle, svaTypography),
+    [newTheme, spacing, bodyTextStyle, svaTypography]
+  );
 
   // modal fields (LOGIC UNCHANGED)
   const [startDate, setStartDate] = useState<Date>(new Date());
@@ -87,18 +95,23 @@ export default function StartDateModal({
   const [error, setError] = useState<string>("");
 
   const daysOfWeek = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+  const handleClose = () => {
+    setError("");
+    onClose();
+  };
+
+  const asDate = (value?: Date | string | null) => {
+    if (!value) return undefined;
+    return value instanceof Date ? value : fromApiDate(value);
+  };
 
   // init from edit mode (LOGIC UNCHANGED)
   useEffect(() => {
     if (!visible) return;
 
     if (isEditMode) {
-      const sd = isEditMode.start_date
-        ? new Date(isEditMode.start_date)
-        : new Date();
-      const ed = isEditMode.end_date
-        ? new Date(isEditMode.end_date)
-        : undefined;
+      const sd = asDate(isEditMode.start_date) ?? new Date();
+      const ed = asDate(isEditMode.end_date);
 
       setStartDate(sd);
 
@@ -313,54 +326,44 @@ export default function StartDateModal({
 
   return (
     <Modal
-      animationType="none"
+      animationType="slide"
       transparent
       visible={visible}
-      onRequestClose={onClose}
       statusBarTranslucent
+      onRequestClose={handleClose}
     >
-      {/* Backdrop */}
-      <TouchableWithoutFeedback onPress={onClose}>
-        <View style={styles.backdrop} />
-      </TouchableWithoutFeedback>
+      <View style={styles.overlay}>
+        <TouchableWithoutFeedback onPress={handleClose}>
+          <View style={styles.backdrop} />
+        </TouchableWithoutFeedback>
 
-      <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-        style={styles.centering}
-      >
-        <SafeAreaView style={styles.safe}>
-          <View style={styles.card}>
-            {/* Header */}
-            <View style={styles.header}>
-              <View style={{ flex: 1, paddingRight: 10 }}>
-                <Text style={styles.title}>Start date</Text>
-                <Text style={styles.subtitle}>
-                  Choose when this habit begins — and optionally repeats.
-                </Text>
-              </View>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+          style={styles.centering}
+        >
+          <SafeAreaView style={styles.safe}>
+            <View style={styles.sheet}>
+              <View style={styles.sheetHandle} />
+              <ModalHeader
+                title={title}
+                subtitle={subtitle}
+                onClose={handleClose}
+                style={styles.modalHeaderCompact}
+                titleStyle={styles.headerTitle}
+                subtitleStyle={styles.headerSubtitle}
+              />
 
-              <TouchableOpacity onPress={onClose} accessibilityLabel="Close">
-                <Ionicons name="close" size={22} color={newTheme.textPrimary} />
-              </TouchableOpacity>
-              {/* 
-              <TouchableOpacity onPress={onClose} style={styles.closeBtn}>
-                <Ionicons name="close" size={22} color={newTheme.textPrimary} />
-              </TouchableOpacity> */}
-            </View>
-
-            {/* Scroll content */}
-            <ScrollView
-              showsVerticalScrollIndicator={false}
-              contentContainerStyle={[styles.content, { paddingBottom: 24 }]}
-              // contentContainerStyle={styles.content}
-              keyboardShouldPersistTaps="handled"
-            >
+              <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={styles.content}
+                keyboardShouldPersistTaps="handled"
+              >
               {/* Start */}
               <View style={styles.section}>
                 <Text style={styles.sectionLabel}>Start</Text>
 
                 <DateInput
-                  label="Start date"
+                  label=""
                   title="Start date"
                   value={startDate}
                   minimumDate={new Date()}
@@ -609,7 +612,7 @@ export default function StartDateModal({
                       {isEndDateEnabled && (
                         <View style={{ marginTop: 10 }}>
                           <DateInput
-                            label="End date"
+                            label=""
                             title="End date"
                             value={endDate < minEndDate ? minEndDate : endDate}
                             minimumDate={minEndDate}
@@ -631,14 +634,18 @@ export default function StartDateModal({
                 )}
               </View>
 
-              {error ? <Text style={styles.error}>{error}</Text> : null}
+              {error ? (
+                <View style={styles.errorBox}>
+                  <Text style={styles.error}>{error}</Text>
+                </View>
+              ) : null}
             </ScrollView>
 
             {/* Sticky footer */}
             <View style={styles.footer}>
               <StyledButton
                 label="Cancel"
-                onPress={onClose}
+                onPress={handleClose}
                 variant="outline"
                 style={styles.footerBtn}
               />
@@ -652,116 +659,135 @@ export default function StartDateModal({
           </View>
         </SafeAreaView>
       </KeyboardAvoidingView>
+      </View>
     </Modal>
   );
 }
 
-const styling = (t: any) =>
+const styling = (t: any, spacing: any, bodyTextStyle: any, svaTypography: any) =>
   StyleSheet.create({
+    overlay: {
+      flex: 1,
+      justifyContent: "flex-end",
+    },
     backdrop: {
       ...StyleSheet.absoluteFillObject,
-      backgroundColor: "rgba(0,0,0,0.52)",
+      backgroundColor: "rgba(0,0,0,0.62)",
     },
-
-    centering: { flex: 1, justifyContent: "center" },
-
+    centering: {
+      flex: 1,
+      justifyContent: "flex-end",
+    },
     safe: {
       width: "100%",
-      paddingHorizontal: 18, // matches HabitDuration feel
+      paddingHorizontal: 14,
+      paddingBottom: 12,
     },
-
-    card: {
-      backgroundColor: t.surface,
-      borderRadius: 20,
-      borderWidth: StyleSheet.hairlineWidth,
-      borderColor: t.divider,
+    sheet: {
+      backgroundColor: t.surfaceMuted,
+      borderTopLeftRadius: 36,
+      borderTopRightRadius: 36,
+      borderWidth: 1,
+      borderColor: t.borderMuted,
       overflow: "hidden",
       maxWidth: 720,
       alignSelf: "center",
       width: "100%",
-      maxHeight: "86%", // ✅ footer never goes out
+      maxHeight: "94%",
       ...Platform.select({
         ios: {
           shadowColor: "#000",
-          shadowOpacity: 0.26,
-          shadowOffset: { width: 0, height: 12 },
-          shadowRadius: 28,
+          shadowOpacity: 0.24,
+          shadowOffset: { width: 0, height: 16 },
+          shadowRadius: 30,
         },
-        android: { elevation: 14 },
+        android: { elevation: 16 },
       }),
     },
-
-    header: {
-      paddingHorizontal: 18,
-      paddingTop: 18,
-      paddingBottom: 12,
-      flexDirection: "row",
-      alignItems: "center",
-      justifyContent: "space-between",
+    sheetHandle: {
+      alignSelf: "center",
+      width: 54,
+      height: 5,
+      borderRadius: 999,
+      backgroundColor: t.borderMuted,
+      marginTop: 10,
+      marginBottom: 10,
     },
-    closeBtn: {
-      width: 36,
-      height: 36,
-      borderRadius: 18,
-      alignItems: "center",
-      justifyContent: "center",
-      backgroundColor: "rgba(255,255,255,0.06)",
+    modalHeaderCompact: {
+      paddingHorizontal: spacing.xl,
+      paddingTop: 0,
+      paddingBottom: 8,
     },
-    title: {
-      fontSize: 20,
-      fontWeight: "800",
+    headerTitle: {
+      ...(svaTypography?.textStyle?.displayMedium ?? {}),
+      fontSize: 28,
+      lineHeight: 32,
       color: t.textPrimary,
-      letterSpacing: 0.2,
+      fontStyle: "normal",
     },
-    subtitle: {
-      marginTop: 4,
+    headerSubtitle: {
+      ...bodyTextStyle,
       fontSize: 13,
-      color: t.textSecondary,
       lineHeight: 18,
+      color: t.textSecondary,
     },
-
     content: {
-      paddingHorizontal: 18,
-      paddingBottom: 14,
+      paddingHorizontal: spacing.xl,
+      paddingBottom: spacing.lg,
     },
-
     section: {
-      paddingTop: 8,
-      paddingBottom: 6,
+      padding: spacing.lg,
+      borderRadius: 24,
+      backgroundColor: t.surface,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: t.borderMuted,
+      marginBottom: spacing.lg,
+      ...Platform.select({
+        ios: {
+          shadowColor: "#000",
+          shadowOpacity: 0.12,
+          shadowOffset: { width: 0, height: 8 },
+          shadowRadius: 18,
+        },
+        android: { elevation: 3 },
+      }),
+    },
+    sectionCopy: {
+      flex: 1,
     },
     sectionLabel: {
-      fontSize: 14,
+      fontSize: 11,
       fontWeight: "700",
-      color: t.textPrimary,
+      color: t.textSecondary,
       marginBottom: 8,
+      letterSpacing: 1.4,
+      textTransform: "uppercase",
     },
     sectionHint: {
       marginTop: 4,
       fontSize: 12,
       color: t.textSecondary,
+      lineHeight: 16,
     },
-
     rowBetween: {
       flexDirection: "row",
       justifyContent: "space-between",
       alignItems: "center",
     },
-
     pillsRow: {
       flexDirection: "row",
       gap: 10,
-      marginTop: 12,
+      marginTop: 14,
     } as any,
-
     pill: {
       flex: 1,
       height: 44,
       borderRadius: 999,
       alignItems: "center",
       justifyContent: "center",
-      backgroundColor: "rgba(255,255,255,0.06)",
+      backgroundColor: t.surfaceMuted,
       borderWidth: StyleSheet.hairlineWidth,
-      borderColor: "rgba(255,255,255,0.08)",
+      borderColor: t.borderMuted,
     },
     pillSelected: {
       backgroundColor: t.accent,
@@ -772,15 +798,16 @@ const styling = (t: any) =>
       fontWeight: "700",
       fontSize: 14,
     },
-    pillTextSelected: { color: t.background },
-
+    pillTextSelected: {
+      color: t.background,
+    },
     block: {
-      marginTop: 12,
-      padding: 12,
-      borderRadius: 16,
-      backgroundColor: "rgba(255,255,255,0.04)",
+      marginTop: 14,
+      padding: 14,
+      borderRadius: 20,
+      backgroundColor: t.surfaceMuted,
       borderWidth: StyleSheet.hairlineWidth,
-      borderColor: "rgba(255,255,255,0.06)",
+      borderColor: t.borderMuted,
     },
     blockTitle: {
       fontSize: 14,
@@ -793,7 +820,6 @@ const styling = (t: any) =>
       color: t.textSecondary,
       lineHeight: 16,
     },
-
     inlineRow: {
       flexDirection: "row",
       alignItems: "center",
@@ -801,30 +827,28 @@ const styling = (t: any) =>
     },
     smallLabel: {
       color: t.textSecondary,
-      fontSize: 14,
+      fontSize: 13,
       marginRight: 10,
       fontWeight: "600",
     },
-
     numberInput: {
       width: 72,
-      height: 44,
-      borderRadius: 12,
+      minHeight: 44,
+      borderRadius: 14,
       borderWidth: StyleSheet.hairlineWidth,
-      borderColor: "rgba(255,255,255,0.10)",
-      backgroundColor: "rgba(0,0,0,0.18)",
+      borderColor: t.borderMuted,
+      backgroundColor: t.background,
       textAlign: "center",
       fontSize: 16,
       fontWeight: "700",
       paddingHorizontal: 10,
       marginRight: 10,
     },
-
     daysRow: {
       flexDirection: "row",
       flexWrap: "wrap",
       gap: 10,
-      marginTop: 10,
+      marginTop: 12,
     } as any,
     dayPill: {
       width: 44,
@@ -832,19 +856,26 @@ const styling = (t: any) =>
       borderRadius: 22,
       alignItems: "center",
       justifyContent: "center",
-      backgroundColor: "rgba(0,0,0,0.18)",
+      backgroundColor: t.background,
       borderWidth: StyleSheet.hairlineWidth,
-      borderColor: "rgba(255,255,255,0.08)",
+      borderColor: t.borderMuted,
     },
-    dayPillSelected: { backgroundColor: t.accent, borderColor: t.accent },
-    dayText: { color: t.textPrimary, fontWeight: "700" },
-    dayTextSelected: { color: t.background },
-
+    dayPillSelected: {
+      backgroundColor: t.accent,
+      borderColor: t.accent,
+    },
+    dayText: {
+      color: t.textPrimary,
+      fontWeight: "700",
+    },
+    dayTextSelected: {
+      color: t.background,
+    },
     monthGrid: {
       flexDirection: "row",
       flexWrap: "wrap",
       gap: 10,
-      marginTop: 10,
+      marginTop: 12,
     } as any,
     monthDay: {
       width: 36,
@@ -852,29 +883,48 @@ const styling = (t: any) =>
       borderRadius: 18,
       alignItems: "center",
       justifyContent: "center",
-      backgroundColor: "rgba(0,0,0,0.18)",
+      backgroundColor: t.background,
       borderWidth: StyleSheet.hairlineWidth,
-      borderColor: "rgba(255,255,255,0.08)",
+      borderColor: t.borderMuted,
     },
-    monthDaySelected: { backgroundColor: t.accent, borderColor: t.accent },
-    monthDayText: { color: t.textPrimary, fontSize: 12, fontWeight: "700" },
-    monthDayTextSelected: { color: t.background },
-
+    monthDaySelected: {
+      backgroundColor: t.accent,
+      borderColor: t.accent,
+    },
+    monthDayText: {
+      color: t.textPrimary,
+      fontSize: 12,
+      fontWeight: "700",
+    },
+    monthDayTextSelected: {
+      color: t.background,
+    },
+    errorBox: {
+      marginBottom: spacing.lg,
+      padding: 12,
+      borderRadius: 18,
+      backgroundColor: "rgba(228,104,104,0.08)",
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: "rgba(228,104,104,0.25)",
+    },
     error: {
       color: t.error ?? "#FF7A7A",
-      marginTop: 10,
       textAlign: "center",
       fontWeight: "600",
+      lineHeight: 18,
     },
-
     footer: {
-      paddingHorizontal: 18,
-      paddingTop: 12,
-      paddingBottom: 16,
+      paddingHorizontal: spacing.xl,
+      paddingTop: spacing.lg,
+      paddingBottom: spacing.lg,
       flexDirection: "row",
       gap: 10,
       borderTopWidth: StyleSheet.hairlineWidth,
-      borderTopColor: "rgba(255,255,255,0.06)",
+      borderTopColor: t.borderMuted,
+      backgroundColor: t.surfaceMuted,
     } as any,
-    footerBtn: { flex: 1 },
+    footerBtn: {
+      flex: 1,
+      minHeight: 52,
+    },
   });

--- a/features/habit/components/create-habit/style/HabitInputStyle.ts
+++ b/features/habit/components/create-habit/style/HabitInputStyle.ts
@@ -1,4 +1,4 @@
-import { View, TouchableOpacity, StyleSheet, Platform } from "react-native";
+import { StyleSheet } from "react-native";
 
 const styling = (newTheme: any, spacing: any) =>
   StyleSheet.create({
@@ -50,6 +50,9 @@ const styling = (newTheme: any, spacing: any) =>
       color: newTheme.textSecondary || "red",
       fontSize: 15,
     },
+    rowLabelNoIcon: {
+      marginLeft: 0,
+    },
     // rowRight: { flexDirection: "row", alignItems: "center", gap: 8 },
     // rowValue: { color: newTheme.textPrimary, fontSize: 15, fontWeight: "600" },
     rowItem: {
@@ -69,7 +72,7 @@ const styling = (newTheme: any, spacing: any) =>
       alignItems: "center",
       justifyContent: "flex-end",
       flexShrink: 1, // allow right side to shrink
-      maxWidth: "55%", // tweak: 50–65% depending on your UI
+      maxWidth: "62%", // give recurrence text a little more room
     },
 
     rowValue: {
@@ -79,6 +82,18 @@ const styling = (newTheme: any, spacing: any) =>
       color: newTheme.textPrimary,
       fontSize: 15,
       fontWeight: "600",
+    },
+    rowValueStack: {
+      flexShrink: 1,
+      alignItems: "flex-end",
+    },
+    rowValueSecondary: {
+      marginTop: 2,
+      textAlign: "right",
+      color: newTheme.textSecondary,
+      fontSize: 12,
+      fontWeight: "500",
+      lineHeight: 16,
     },
   });
 

--- a/features/habit/components/create-protocol/Modal/ProtocolColorPickerModal.tsx
+++ b/features/habit/components/create-protocol/Modal/ProtocolColorPickerModal.tsx
@@ -1,0 +1,143 @@
+import React, { useContext, useMemo } from "react";
+import {
+  Modal,
+  View,
+  StyleSheet,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+
+import ThemeContext from "@/contexts/ThemeContext";
+import ModalHeader from "@/components/ui/modal/ModalHeader";
+
+export type ProtocolColorOption = {
+  label: string;
+  value: string;
+};
+
+export const PROTOCOL_COLOR_OPTIONS: ProtocolColorOption[] = [
+  { label: "Rose Silk", value: "#FFEDFA" },
+  { label: "Mint Frost", value: "#B4EBE6" },
+  { label: "Solar Dust", value: "#F8ED8C" },
+  { label: "Moss Aura", value: "#C1CFA1" },
+  { label: "Iris Mist", value: "#B7B1F2" },
+];
+
+type ProtocolColorPickerModalProps = {
+  visible: boolean;
+  onClose: () => void;
+  selectedColor: ProtocolColorOption;
+  onSelect: (color: ProtocolColorOption) => void;
+  title?: string;
+};
+
+export default function ProtocolColorPickerModal({
+  visible,
+  onClose,
+  selectedColor,
+  onSelect,
+  title = "Choose Aura",
+}: ProtocolColorPickerModalProps) {
+  const { newTheme, spacing } = useContext(ThemeContext);
+
+  const styles = useMemo(
+    () => makeStyles(newTheme, spacing),
+    [newTheme, spacing]
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <TouchableWithoutFeedback onPress={onClose}>
+          <View style={styles.backdrop} />
+        </TouchableWithoutFeedback>
+
+        <View style={styles.container}>
+          <ModalHeader
+            title={title}
+            onClose={onClose}
+            style={styles.headerCompact}
+          />
+
+          <View style={styles.colorsGrid}>
+            {PROTOCOL_COLOR_OPTIONS.map((item) => {
+              const isSelected = selectedColor.value === item.value;
+
+              return (
+                <TouchableOpacity
+                  key={item.value}
+                  style={[
+                    styles.colorOption,
+                    { backgroundColor: item.value },
+                    isSelected && styles.selectedColorOption,
+                  ]}
+                  onPress={() => {
+                    onSelect(item);
+                    onClose();
+                  }}
+                >
+                  {isSelected && (
+                    <Ionicons
+                      name="checkmark"
+                      size={24}
+                      color="rgba(0,0,0,0.3)"
+                    />
+                  )}
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const makeStyles = (colors: any, spacing: any) =>
+  StyleSheet.create({
+    overlay: {
+      flex: 1,
+      justifyContent: "flex-end",
+    },
+    backdrop: {
+      ...StyleSheet.absoluteFillObject,
+      backgroundColor: colors.overlayStrong,
+    },
+    container: {
+      width: "100%",
+      backgroundColor: colors.surfaceMuted,
+      borderRadius: 32,
+      padding: spacing.xl,
+      alignItems: "center",
+      borderWidth: 1,
+      borderColor: colors.borderMuted,
+    },
+    headerCompact: {
+      paddingHorizontal: 0,
+      paddingTop: 0,
+      paddingBottom: 12,
+    },
+    colorsGrid: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      justifyContent: "center",
+      gap: spacing.md,
+    },
+    colorOption: {
+      width: 60,
+      height: 60,
+      borderRadius: 30,
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    selectedColorOption: {
+      borderWidth: 3,
+      borderColor: colors.accent,
+    },
+  });

--- a/features/habit/components/create-protocol/Modal/ProtocolTypePickerModal.tsx
+++ b/features/habit/components/create-protocol/Modal/ProtocolTypePickerModal.tsx
@@ -1,0 +1,208 @@
+import React, { useContext, useEffect, useMemo, useState } from "react";
+import {
+  Modal,
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  TextInput,
+  FlatList,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+
+import ThemeContext from "@/contexts/ThemeContext";
+import ModalHeader from "@/components/ui/modal/ModalHeader";
+import { HabitType } from "@/features/habit/types/habitTypes";
+
+type ProtocolTypePickerModalProps = {
+  visible: boolean;
+  onClose: () => void;
+  types: HabitType[];
+  selectedTypeId: number | null;
+  onSelect: (type: HabitType) => void;
+  title?: string;
+};
+
+export default function ProtocolTypePickerModal({
+  visible,
+  onClose,
+  types,
+  selectedTypeId,
+  onSelect,
+  title = "Select Protocol Type",
+}: ProtocolTypePickerModalProps) {
+  const { newTheme, spacing, svaTypography, typography } =
+    useContext(ThemeContext);
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    if (visible) {
+      setSearch("");
+    }
+  }, [visible]);
+
+  const bodyTextStyle = svaTypography?.textStyle?.body ?? typography.body;
+
+  const styles = useMemo(
+    () => makeStyles(newTheme, spacing, bodyTextStyle),
+    [newTheme, spacing, bodyTextStyle]
+  );
+
+  const filteredTypes = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return types;
+    return types.filter((type) => {
+      const name = type.name?.toLowerCase() ?? "";
+      const description = type.description?.toLowerCase() ?? "";
+      return name.includes(query) || description.includes(query);
+    });
+  }, [search, types]);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <TouchableWithoutFeedback onPress={onClose}>
+          <View style={styles.backdrop} />
+        </TouchableWithoutFeedback>
+
+        <View style={styles.container}>
+          <ModalHeader
+            title={title}
+            onClose={onClose}
+            style={styles.headerCompact}
+          />
+
+          <View style={styles.searchBar}>
+            <Ionicons
+              name="search"
+              size={20}
+              color={newTheme.textSecondary}
+            />
+            <TextInput
+              style={styles.searchInput}
+              placeholder="Search protocol types..."
+              placeholderTextColor={newTheme.textDisabled}
+              value={search}
+              onChangeText={setSearch}
+            />
+          </View>
+
+          <FlatList
+            data={filteredTypes}
+            keyExtractor={(item) => item.id.toString()}
+            renderItem={({ item }) => {
+              const isSelected = selectedTypeId === item.id;
+
+              return (
+                <TouchableOpacity
+                  style={styles.typeOption}
+                  onPress={() => {
+                    onSelect(item);
+                    onClose();
+                  }}
+                >
+                  <Text
+                    style={[
+                      styles.typeOptionText,
+                      isSelected && styles.selectedTypeText,
+                    ]}
+                    numberOfLines={1}
+                  >
+                    {item.name}
+                  </Text>
+                  {isSelected && (
+                    <Ionicons
+                      name="checkmark"
+                      size={20}
+                      color={newTheme.accent}
+                    />
+                  )}
+                </TouchableOpacity>
+              );
+            }}
+            style={styles.typeList}
+            showsVerticalScrollIndicator={false}
+            ListEmptyComponent={
+              <Text style={styles.emptyState}>No protocol types found.</Text>
+            }
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const makeStyles = (colors: any, spacing: any, bodyTextStyle: any) =>
+  StyleSheet.create({
+    overlay: {
+      flex: 1,
+      justifyContent: "flex-end",
+    },
+    backdrop: {
+      ...StyleSheet.absoluteFillObject,
+      backgroundColor: colors.overlayStrong,
+    },
+    container: {
+      width: "100%",
+      height: "75%",
+      backgroundColor: colors.surfaceMuted,
+      borderTopLeftRadius: 32,
+      borderTopRightRadius: 32,
+      padding: spacing.xl,
+      borderWidth: 1,
+      borderColor: colors.borderMuted,
+    },
+    headerCompact: {
+      paddingHorizontal: 0,
+      paddingTop: 0,
+      paddingBottom: 12,
+    },
+    searchBar: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: colors.surface,
+      borderRadius: 16,
+      paddingHorizontal: spacing.md,
+      height: 52,
+      marginBottom: spacing.lg,
+    },
+    searchInput: {
+      flex: 1,
+      marginLeft: spacing.sm,
+      color: colors.textPrimary,
+      ...bodyTextStyle,
+    },
+    typeList: {
+      flex: 1,
+    },
+    typeOption: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      paddingVertical: spacing.md,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.borderMuted,
+    },
+    typeOptionText: {
+      ...bodyTextStyle,
+      color: colors.textSecondary,
+      flex: 1,
+      paddingRight: spacing.md,
+    },
+    selectedTypeText: {
+      color: colors.textPrimary,
+      fontWeight: "700",
+    },
+    emptyState: {
+      ...bodyTextStyle,
+      color: colors.textSecondary,
+      textAlign: "center",
+      paddingVertical: spacing.xl,
+    },
+  });

--- a/features/habit/components/create-protocol/Modal/ProtocolUnitPickerModal.tsx
+++ b/features/habit/components/create-protocol/Modal/ProtocolUnitPickerModal.tsx
@@ -1,0 +1,203 @@
+import React, { useContext, useEffect, useMemo, useState } from "react";
+import {
+  Modal,
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  TextInput,
+  FlatList,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+
+import ThemeContext from "@/contexts/ThemeContext";
+import ModalHeader from "@/components/ui/modal/ModalHeader";
+import { HabitUnit } from "@/features/habit/types/habitTypes";
+
+type ProtocolUnitPickerModalProps = {
+  visible: boolean;
+  onClose: () => void;
+  units: HabitUnit[];
+  selectedUnitId: number;
+  onSelect: (unit: HabitUnit) => void;
+  title?: string;
+};
+
+export default function ProtocolUnitPickerModal({
+  visible,
+  onClose,
+  units,
+  selectedUnitId,
+  onSelect,
+  title = "Select Metric",
+}: ProtocolUnitPickerModalProps) {
+  const { newTheme, spacing, svaTypography, typography } =
+    useContext(ThemeContext);
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    if (visible) {
+      setSearch("");
+    }
+  }, [visible]);
+
+  const bodyTextStyle = svaTypography?.textStyle?.body ?? typography.body;
+
+  const styles = useMemo(
+    () => makeStyles(newTheme, spacing, bodyTextStyle),
+    [newTheme, spacing, bodyTextStyle]
+  );
+
+  const filteredUnits = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return units;
+    return units.filter((unit) =>
+      unit.name.toLowerCase().includes(query)
+    );
+  }, [search, units]);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <TouchableWithoutFeedback onPress={onClose}>
+          <View style={styles.backdrop} />
+        </TouchableWithoutFeedback>
+
+        <View style={styles.container}>
+          <ModalHeader
+            title={title}
+            onClose={onClose}
+            style={styles.headerCompact}
+          />
+
+          <View style={styles.searchBar}>
+            <Ionicons
+              name="search"
+              size={20}
+              color={newTheme.textSecondary}
+            />
+            <TextInput
+              style={styles.searchInput}
+              placeholder="Search units..."
+              placeholderTextColor={newTheme.textDisabled}
+              value={search}
+              onChangeText={setSearch}
+            />
+          </View>
+
+          <FlatList
+            data={filteredUnits}
+            keyExtractor={(item) => item.id.toString()}
+            renderItem={({ item }) => {
+              const isSelected = selectedUnitId === item.id;
+
+              return (
+                <TouchableOpacity
+                  style={styles.unitOption}
+                  onPress={() => {
+                    onSelect(item);
+                    onClose();
+                  }}
+                >
+                  <Text
+                    style={[
+                      styles.unitOptionText,
+                      isSelected && styles.selectedUnitText,
+                    ]}
+                  >
+                    {item.name}
+                  </Text>
+                  {isSelected && (
+                    <Ionicons
+                      name="checkmark"
+                      size={20}
+                      color={newTheme.accent}
+                    />
+                  )}
+                </TouchableOpacity>
+              );
+            }}
+            style={styles.unitList}
+            showsVerticalScrollIndicator={false}
+            ListEmptyComponent={
+              <Text style={styles.emptyState}>No units found.</Text>
+            }
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const makeStyles = (colors: any, spacing: any, bodyTextStyle: any) =>
+  StyleSheet.create({
+    overlay: {
+      flex: 1,
+      justifyContent: "flex-end",
+    },
+    backdrop: {
+      ...StyleSheet.absoluteFillObject,
+      backgroundColor: colors.overlayStrong,
+    },
+    container: {
+      width: "100%",
+      height: "75%",
+      backgroundColor: colors.surfaceMuted,
+      borderTopLeftRadius: 32,
+      borderTopRightRadius: 32,
+      padding: spacing.xl,
+      borderWidth: 1,
+      borderColor: colors.borderMuted,
+    },
+    headerCompact: {
+      paddingHorizontal: 0,
+      paddingTop: 0,
+      paddingBottom: 12,
+    },
+    searchBar: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: colors.surface,
+      borderRadius: 16,
+      paddingHorizontal: spacing.md,
+      height: 52,
+      marginBottom: spacing.lg,
+    },
+    searchInput: {
+      flex: 1,
+      marginLeft: spacing.sm,
+      color: colors.textPrimary,
+      ...bodyTextStyle,
+    },
+    unitList: {
+      flex: 1,
+    },
+    unitOption: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      paddingVertical: spacing.md,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.borderMuted,
+    },
+    unitOptionText: {
+      ...bodyTextStyle,
+      color: colors.textSecondary,
+    },
+    selectedUnitText: {
+      color: colors.textPrimary,
+      fontWeight: "700",
+    },
+    emptyState: {
+      ...bodyTextStyle,
+      color: colors.textSecondary,
+      textAlign: "center",
+      paddingVertical: spacing.xl,
+    },
+  });

--- a/features/habit/screens/CreateHabitScreen.tsx
+++ b/features/habit/screens/CreateHabitScreen.tsx
@@ -1,10 +1,8 @@
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import {
   View,
-  TouchableOpacity,
   StyleSheet,
   TextInput,
-  ActivityIndicator,
   SafeAreaView,
   ScrollView,
   Pressable,
@@ -31,10 +29,10 @@ import EmojiSelector from "@/features/habit/components/create-habit/EmojiSelecto
 import AppHeader from "@/components/layout/AppHeader";
 
 import { createHabit } from "@/features/habit/services/habitService";
+import { fromApiDate, toApiDate, toBackendTime } from "@/utils/date-time";
 
 import {
   ReminderAt,
-  FrequencyObj,
   MetricFormat,
   Duration,
   HabitDateType,
@@ -58,9 +56,8 @@ export const CreateHabitScreen = () => {
   const [name, setName] = useState("");
   const [habitTypeId, sethabitTypeId] = useState<number>(0);
   const [tags, setTags] = useState<selectedTag>({} as selectedTag);
-  const [metric, setMetric] = useState<MetricFormat | {}>({});
-  const [frequency, setFrequency] = useState<FrequencyObj | null>(null);
-  const [duration, setDuration] = useState<Duration>({ all_day: undefined });
+  const [metric, setMetric] = useState<MetricFormat | null>(null);
+  const [duration, setDuration] = useState<Duration>({ all_day: true });
   const [date, setDate] = useState<HabitDateType>();
   const [reminderAt, setReminderAt] = useState<ReminderAt>({});
   const [emoji, setEmoji] = useState<string>("🙂");
@@ -108,16 +105,69 @@ export const CreateHabitScreen = () => {
     setDate(v);
   };
 
-  const handleFrequencySelect = (v: any) => setFrequency(v);
-
   const handleReminderSelect = useCallback((v: any) => {
     setReminderAt(v);
     console.log(v, "selected reminder details");
   }, []);
 
-  const getFrequencyDetail = () => {
-    if (frequency?.frequency_type || date?.start_date)
-      return { ...frequency, ...date };
+  const normalizeDateValue = (value?: Date | string | null) => {
+    if (!value) return undefined;
+    const parsed = value instanceof Date ? value : fromApiDate(value);
+    return toApiDate(parsed);
+  };
+
+  const normalizeDurationForBackend = (value: any) => {
+    if (!value || value.all_day) return { all_day: true };
+
+    const payload: any = {};
+    if (value.start_time) {
+      payload.start_time =
+        typeof value.start_time === "string"
+          ? value.start_time
+          : toBackendTime(value.start_time);
+    }
+    if (value.end_time) {
+      payload.end_time =
+        typeof value.end_time === "string"
+          ? value.end_time
+          : toBackendTime(value.end_time);
+    }
+
+    return payload;
+  };
+
+  const normalizeFrequencyForBackend = (value?: any) => {
+    const payload: any = {
+      start_date: normalizeDateValue(value?.start_date) ?? toApiDate(new Date()),
+    };
+
+    const endDate = normalizeDateValue(value?.end_date);
+    if (endDate) payload.end_date = endDate;
+
+    if (value?.frequency_type) payload.frequency_type = value.frequency_type;
+    if (typeof value?.interval === "number") payload.interval = value.interval;
+    if (value?.days_of_week?.length) payload.days_of_week = value.days_of_week;
+    if (value?.days_of_month?.length) payload.days_of_month = value.days_of_month;
+
+    return payload;
+  };
+
+  const normalizeReminderForBackend = (value?: any) => {
+    if (!value) return {};
+
+    if (value.time) {
+      return {
+        time:
+          typeof value.time === "string"
+            ? value.time
+            : toBackendTime(value.time),
+      };
+    }
+
+    if (value.ten_min_before) return { ten_min_before: true };
+    if (value.thirty_min_before) return { thirty_min_before: true };
+
+    return {};
   };
 
   const getFormattedTag = () => {
@@ -132,18 +182,20 @@ export const CreateHabitScreen = () => {
 
   const validateAndBuild = () => {
     if (!name.trim()) return { ok: false, msg: "Please enter a habit name." };
-    if (!Object.keys(metric).length)
+    if (!metric || !Object.keys(metric).length)
       return { ok: false, msg: "Please choose a metric." };
     if (!Object.keys(reminderAt).length)
       return { ok: false, msg: "Please set a reminder." };
 
-    const freq = getFrequencyDetail();
+    const freq = normalizeFrequencyForBackend(date);
+    const durationPayload = normalizeDurationForBackend(duration);
+    const reminderPayload = normalizeReminderForBackend(reminderAt);
     const payload: any = {
       name: name.trim(),
       habit_type_id: habitTypeId,
       color: colorSchema,
       habit_metric: metric,
-      habit_duration: duration,
+      habit_duration: durationPayload,
       habit_frequency: freq,
       tags: getFormattedTag(),
       icon: emoji,
@@ -151,8 +203,7 @@ export const CreateHabitScreen = () => {
 
     console.log(payload, "final payload");
 
-    if (reminderAt?.time || reminderAt?.ten_min_before)
-      payload.remind_at = reminderAt;
+    if (Object.keys(reminderPayload).length) payload.remind_at = reminderPayload;
     return { ok: true, payload };
   };
 
@@ -176,7 +227,7 @@ export const CreateHabitScreen = () => {
           message: "Failed to create habit",
         });
       }
-    } catch (err: any) {
+    } catch {
       toast.show({
         variant: "error",
         title: "Somthing went wrong",
@@ -336,6 +387,7 @@ export const CreateHabitScreen = () => {
               <HabitDurationInput
                 style={styles.rowItem}
                 onSelect={handleDurationSelect}
+                label="Rhythm"
               />
               <HabitDateInput
                 style={styles.rowItem}

--- a/features/habit/screens/CreateProtocolScreen.tsx
+++ b/features/habit/screens/CreateProtocolScreen.tsx
@@ -1,0 +1,840 @@
+import React, { useState, useContext, useEffect, useMemo } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TextInput,
+  TouchableOpacity,
+  SafeAreaView,
+  Platform,
+  ActivityIndicator,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { router, useNavigation } from "expo-router";
+import EmojiPicker, { type EmojiType } from "rn-emoji-keyboard";
+import ThemeContext from "@/contexts/ThemeContext";
+import AppHeader from "@/components/layout/AppHeader";
+import { ScreenView } from "@/components/ui/Themed";
+import {
+  createHabit,
+  getHabitTag,
+  getHabitType,
+  getHabitUnitData,
+} from "@/features/habit/services/habitService";
+import { useNimbusToast } from "@/components/ui/toast/useNimbusToast";
+import { ROUTES } from "@/constants/routes";
+import HabitDurationInput from "@/features/habit/components/create-habit/HabitDurationInput";
+import HabitTagsModal from "@/features/habit/components/create-habit/Modal/HabitTagsModal";
+import StartDateModal from "@/features/habit/components/create-habit/Modal/StartDateModal";
+import TimePickerSheet from "@/components/ui/picker/TimePickerSheet";
+import ProcessingModal from "@/components/ui/modal/ProcessingModal";
+import ProtocolColorPickerModal, {
+  PROTOCOL_COLOR_OPTIONS,
+  type ProtocolColorOption,
+} from "@/features/habit/components/create-protocol/Modal/ProtocolColorPickerModal";
+import ProtocolTypePickerModal from "@/features/habit/components/create-protocol/Modal/ProtocolTypePickerModal";
+import ProtocolUnitPickerModal from "@/features/habit/components/create-protocol/Modal/ProtocolUnitPickerModal";
+import {
+  formatTimeUI,
+  toBackendTime,
+  fromApiDate,
+  toApiDate,
+  toFriendlyDate,
+} from "@/utils/date-time";
+import { formatProtocolFrequencySummary } from "@/features/habit/utils/protocolDisplay";
+import {
+  HabitDateType,
+  HabitTag,
+  HabitUnit,
+  HabitType,
+} from "@/features/habit/types/habitTypes";
+
+const CreateProtocolScreen = () => {
+  const { svaColors, svaTypography, spacing } = useContext(ThemeContext);
+  const navigation = useNavigation();
+  const toast = useNimbusToast();
+
+  // Core State
+  const [name, setName] = useState("");
+  const [metricValue, setMetricValue] = useState(10);
+  const [metricUnit, setMetricUnit] = useState<HabitUnit>({
+    id: 1,
+    name: "Minutes",
+  });
+  const [protocolDuration, setProtocolDuration] = useState<any>({
+    all_day: true,
+  });
+  const [origin, setOrigin] = useState<HabitDateType | null>(null);
+  const [protocolTypes, setProtocolTypes] = useState<HabitType[]>([]);
+  const [selectedProtocolType, setSelectedProtocolType] =
+    useState<HabitType | null>(null);
+  const [natureTags, setNatureTags] = useState<HabitTag[]>([]);
+  const [reminderTime, setReminderTime] = useState(() => new Date());
+
+  // Divine Defaults State
+  const [emoji, setEmoji] = useState("🙂");
+  const [selectedColor, setSelectedColor] = useState<ProtocolColorOption>(
+    PROTOCOL_COLOR_OPTIONS[3]
+  ); // Default Moss Aura
+  const [isLoading, setIsLoading] = useState(false);
+  const [isProcessingModalVisible, setIsProcessingModalVisible] =
+    useState(false);
+
+  // Modals State
+  const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useState(false);
+  const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
+  const [isUnitPickerOpen, setIsUnitPickerOpen] = useState(false);
+  const [isOriginPickerOpen, setIsOriginPickerOpen] = useState(false);
+  const [isProtocolTypeOpen, setIsProtocolTypeOpen] = useState(false);
+  const [isNaturePickerOpen, setIsNaturePickerOpen] = useState(false);
+  const [isTimePickerOpen, setIsTimePickerOpen] = useState(false);
+  const [unitOptions, setUnitOptions] = useState<HabitUnit[]>([]);
+  const [natureOptions, setNatureOptions] = useState<HabitTag[]>([]);
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerShown: false,
+    });
+    fetchUnits();
+  }, [navigation]);
+
+  useEffect(() => {
+    fetchNatureTags();
+    fetchProtocolTypes();
+  }, []);
+
+  const fetchUnits = async () => {
+    try {
+      const result = await getHabitUnitData();
+      if (result?.success) {
+        setUnitOptions(result.data);
+      }
+    } catch (error) {
+      console.error("Error fetching units:", error);
+    }
+  };
+
+  const fetchNatureTags = async () => {
+    try {
+      const result = await getHabitTag();
+      if (result?.success) {
+        setNatureOptions(result.data);
+      }
+    } catch (error) {
+      console.error("Error fetching nature tags:", error);
+    }
+  };
+
+  const fetchProtocolTypes = async () => {
+    try {
+      const result = await getHabitType();
+      if (result?.success) {
+        setProtocolTypes(result.data);
+        setSelectedProtocolType((prev) => prev ?? result.data[0] ?? null);
+      }
+    } catch (error) {
+      console.error("Error fetching protocol types:", error);
+    }
+  };
+
+  const reminderTimeLabel = useMemo(
+    () => formatTimeUI(reminderTime),
+    [reminderTime]
+  );
+
+  const originLabel = useMemo(() => {
+    if (!origin?.start_date) return "Today";
+    return toFriendlyDate(origin.start_date);
+  }, [origin]);
+
+  const originSummaryLabel = useMemo(
+    () => formatProtocolFrequencySummary(origin),
+    [origin]
+  );
+
+  const protocolTypeLabel = useMemo(() => {
+    if (!selectedProtocolType?.name) return "Select Type";
+    return selectedProtocolType.name;
+  }, [selectedProtocolType]);
+
+  const normalizeDateValue = (value?: Date | string | null) => {
+    if (!value) return undefined;
+    const parsed = value instanceof Date ? value : fromApiDate(value);
+    return toApiDate(parsed);
+  };
+
+  const normalizeFrequencyForBackend = (value?: HabitDateType | null) => {
+    const payload: any = {
+      start_date:
+        normalizeDateValue(value?.start_date) ?? toApiDate(new Date()),
+    };
+
+    const endDate = normalizeDateValue(value?.end_date);
+    if (endDate) payload.end_date = endDate;
+
+    if (value?.frequency_type) payload.frequency_type = value.frequency_type;
+    if (typeof value?.interval === "number") payload.interval = value.interval;
+    if (value?.days_of_week?.length) payload.days_of_week = value.days_of_week;
+    if (value?.days_of_month?.length) payload.days_of_month = value.days_of_month;
+
+    return payload;
+  };
+
+  const getFormattedTag = () => {
+    let value;
+    if (natureTags) {
+      const oldIds = natureTags?.filter((it) => it.id !== 0).map((it) => it.id) || [];
+      const newTag = natureTags?.find((it) => it.id === 0)?.name || "";
+      if (newTag) value = { old: oldIds, new: [newTag] };
+      else value = { old: oldIds };
+    } else value = {};
+    return value;
+  };
+
+  const natureValueLabel = useMemo(() => {
+    if (!natureTags.length) return "Select Tags";
+    if (natureTags.length === 1) return natureTags[0].name || "1 Tag Selected";
+    return `${natureTags.length} Tags Selected`;
+  }, [natureTags]);
+
+  const handleNatureTagSelect = (tag: HabitTag) => {
+    setNatureTags((prevTags) => {
+      const exists = prevTags.some((item) => item.id === tag.id);
+      if (exists) return prevTags;
+      return [...prevTags, tag];
+    });
+  };
+
+  const handleNatureTagRemove = (index: number) => {
+    setNatureTags((prevTags) => prevTags.filter((_, i) => i !== index));
+  };
+
+  const validateAndBuild = () => {
+    if (!name.trim()) return { ok: false, msg: "Please enter a ritual name." };
+    const habitFrequency = normalizeFrequencyForBackend(origin);
+
+    const payload = {
+      name: name.trim(),
+      habit_type_id: selectedProtocolType?.id ?? 0,
+      color: selectedColor.value,
+      habit_metric: {
+        count: metricValue.toString(),
+        unit: metricUnit.id,
+      },
+      habit_duration: protocolDuration,
+      habit_frequency: habitFrequency,
+      tags: getFormattedTag(),
+      icon: emoji,
+      remind_at: { time: toBackendTime(reminderTime) },
+    };
+
+    return { ok: true, payload };
+  };
+
+  const onSubmitClick = async () => {
+    const { ok, payload, msg } = validateAndBuild() as any;
+    if (!ok) {
+      toast.show({ variant: "error", title: "Validation Error", message: msg });
+      return;
+    }
+
+    setIsLoading(true);
+    setIsProcessingModalVisible(true);
+    try {
+      const result = await createHabit(payload);
+      if (result?.success) {
+        setIsProcessingModalVisible(false);
+        toast.show({
+          variant: "success",
+          title: "Ritual Sealed",
+          message: "Your ritual has been architected successfully.",
+        });
+        setTimeout(() => {
+          router.replace(ROUTES.TABS.HOME);
+        }, 300);
+      } else {
+        setIsProcessingModalVisible(false);
+        toast.show({
+          variant: "error",
+          title: "Architecture Failed",
+          message: result?.message || "Failed to seal the ritual.",
+        });
+      }
+    } catch {
+      setIsProcessingModalVisible(false);
+      toast.show({
+        variant: "error",
+        title: "Network Error",
+        message: "Unable to reach the collective consciousness.",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleEmojiSelect = (obj: EmojiType) => {
+    setEmoji(obj.emoji);
+    setIsEmojiPickerOpen(false);
+  };
+
+  const styles = styling(svaColors, svaTypography, spacing);
+
+  return (
+    <View style={styles.container}>
+      <SafeAreaView style={{ flex: 1 }}>
+        <ScrollView
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={styles.scrollContent}
+        >
+          <ScreenView bgColor={svaColors.bg.base} style={styles.screenView}>
+            <AppHeader
+              title="Ritual Architect"
+              subtitle="Craft your formula with intention."
+              onBack={() => router.back()}
+            />
+
+            {/* Section 1: Core Details */}
+            <View style={styles.section}>
+              <Text style={styles.label}>RITUAL NAME</Text>
+              <TextInput
+                style={styles.nameInput}
+                placeholder="e.g., Morning Yoga"
+                placeholderTextColor={svaColors.text.disabled}
+                value={name}
+                onChangeText={setName}
+              />
+
+              <Text style={styles.label}>METRIC</Text>
+              <View style={styles.metricRow}>
+                <View style={styles.counterContainer}>
+                  <TouchableOpacity
+                    onPress={() => setMetricValue(Math.max(1, metricValue - 1))}
+                    style={styles.counterBtn}
+                  >
+                    <Ionicons
+                      name="remove"
+                      size={20}
+                      color={svaColors.text.primary}
+                    />
+                  </TouchableOpacity>
+                  <Text style={styles.counterValue}>{metricValue}</Text>
+                  <TouchableOpacity
+                    onPress={() => setMetricValue(metricValue + 1)}
+                    style={styles.counterBtn}
+                  >
+                    <Ionicons
+                      name="add"
+                      size={20}
+                      color={svaColors.text.primary}
+                    />
+                  </TouchableOpacity>
+                </View>
+                <TouchableOpacity
+                  style={styles.unitDropdown}
+                  onPress={() => setIsUnitPickerOpen(true)}
+                >
+                  <Text style={styles.unitText}>{metricUnit.name}</Text>
+                  <Ionicons
+                    name="chevron-down"
+                    size={16}
+                    color={svaColors.text.secondary}
+                  />
+                </TouchableOpacity>
+              </View>
+
+              <View style={styles.durationSection}>
+                <Text style={styles.label}>RHYTHM</Text>
+                <HabitDurationInput
+                  onSelect={setProtocolDuration}
+                  compact
+                  showIcon={false}
+                  showLabel={false}
+                  style={styles.durationChip}
+                />
+              </View>
+
+              <View style={styles.reminderSection}>
+                <Text style={styles.label}>YOUR DAILY NUDGE</Text>
+                <TouchableOpacity
+                  activeOpacity={0.9}
+                  style={styles.reminderTrigger}
+                  onPress={() => setIsTimePickerOpen(true)}
+                >
+                  <Text style={styles.reminderValue}>{reminderTimeLabel}</Text>
+                  <Ionicons
+                    name="chevron-down"
+                    size={16}
+                    color={svaColors.text.secondary}
+                  />
+                </TouchableOpacity>
+              </View>
+            </View>
+
+            {/* Section 2: Divine Defaults */}
+            <View style={styles.divineCard}>
+              <View style={styles.divineHeader}>
+                <Text style={styles.divineTitle}>DIVINE DEFAULTS</Text>
+              </View>
+
+              <View style={styles.gridContainer}>
+                <TouchableOpacity
+                  style={[styles.gridItem, styles.fullWidthItem]}
+                  onPress={() => setIsOriginPickerOpen(true)}
+                >
+                  <View style={[styles.gridCompactBlock, styles.gridCompactBlockWide]}>
+                    <View style={styles.gridTileHeader}>
+                      <Text style={styles.gridLabel}>GENESIS</Text>
+                      <Ionicons
+                        name="chevron-forward"
+                        size={14}
+                        color={svaColors.text.secondary}
+                      />
+                    </View>
+                    <View style={styles.gridValueStack}>
+                      <Text style={styles.gridValueText}>{originLabel}</Text>
+                      {!!originSummaryLabel && (
+                        <Text style={styles.gridValueSubtext}>
+                          {originSummaryLabel}
+                        </Text>
+                      )}
+                    </View>
+                  </View>
+                </TouchableOpacity>
+
+                <View style={styles.gridRow}>
+                  <TouchableOpacity
+                    style={styles.gridItem}
+                    onPress={() => setIsEmojiPickerOpen(true)}
+                  >
+                    <View style={styles.gridTileHeader}>
+                      <Text style={styles.gridLabel}>ESSENCE</Text>
+                      <Ionicons
+                        name="chevron-forward"
+                        size={14}
+                        color={svaColors.text.secondary}
+                      />
+                    </View>
+                    <View style={styles.gridValueRow}>
+                      <Text style={styles.gridEmoji}>{emoji}</Text>
+                    </View>
+                  </TouchableOpacity>
+
+                  <TouchableOpacity
+                    style={styles.gridItem}
+                    onPress={() => setIsColorPickerOpen(true)}
+                  >
+                    <View style={styles.gridTileHeader}>
+                      <Text style={styles.gridLabel}>AURA</Text>
+                      <Ionicons
+                        name="chevron-forward"
+                        size={14}
+                        color={svaColors.text.secondary}
+                      />
+                    </View>
+                    <View style={styles.gridValueRow}>
+                      <View
+                        style={[
+                          styles.colorDot,
+                          { backgroundColor: selectedColor.value },
+                        ]}
+                      />
+                      <Text style={styles.gridValueText}>
+                        {selectedColor.label}
+                      </Text>
+                    </View>
+                  </TouchableOpacity>
+                </View>
+
+                <TouchableOpacity
+                  style={[styles.gridItem, styles.fullWidthItem]}
+                  onPress={() => setIsProtocolTypeOpen(true)}
+                >
+                  <View style={styles.gridCompactBlock}>
+                    <View style={styles.gridTileHeader}>
+                      <Text style={styles.gridLabel}>PROTOCOL TYPE</Text>
+                      <Ionicons
+                        name="chevron-forward"
+                        size={14}
+                        color={svaColors.text.secondary}
+                      />
+                    </View>
+                    <View style={styles.gridValueRow}>
+                      <Text style={styles.gridValueText}>
+                        {protocolTypeLabel}
+                      </Text>
+                    </View>
+                  </View>
+                </TouchableOpacity>
+
+                <TouchableOpacity
+                  style={[styles.gridItem, styles.fullWidthItem]}
+                  onPress={() => setIsNaturePickerOpen(true)}
+                >
+                  <View style={styles.gridCompactBlock}>
+                    <View style={styles.gridTileHeader}>
+                      <Text style={styles.gridLabel}>NATURE</Text>
+                      <Ionicons
+                        name="chevron-forward"
+                        size={14}
+                        color={svaColors.text.secondary}
+                      />
+                    </View>
+                    <View style={styles.gridValueRow}>
+                      <Text style={styles.gridValueText}>
+                        {natureValueLabel}
+                      </Text>
+                    </View>
+                  </View>
+                </TouchableOpacity>
+
+                {natureTags.length > 0 && (
+                  <View style={styles.natureChips}>
+                    {natureTags.map((tag, index) => (
+                      <View key={`${tag.id}-${index}`} style={styles.natureChip}>
+                        <Text style={styles.natureChipText}>{tag.name}</Text>
+                        <TouchableOpacity
+                          onPress={() => handleNatureTagRemove(index)}
+                        >
+                          <Ionicons
+                            name="close-circle"
+                            size={16}
+                            color={svaColors.text.secondary}
+                          />
+                        </TouchableOpacity>
+                      </View>
+                    ))}
+                  </View>
+                )}
+              </View>
+            </View>
+
+            {/* Seal Ritual Button */}
+            <View style={styles.buttonContainer}>
+              <TouchableOpacity
+                style={[styles.sealButton, isLoading && { opacity: 0.7 }]}
+                onPress={onSubmitClick}
+                disabled={isLoading}
+              >
+                {isLoading ? (
+                  <ActivityIndicator color={svaColors.text.inverse} />
+                ) : (
+                  <Text style={styles.sealButtonText}>SEAL RITUAL</Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          </ScreenView>
+        </ScrollView>
+      </SafeAreaView>
+
+      {/* Modals */}
+      <EmojiPicker
+        open={isEmojiPickerOpen}
+        onClose={() => setIsEmojiPickerOpen(false)}
+        onEmojiSelected={handleEmojiSelect}
+        theme={{
+          backdrop: svaColors.overlay.strong,
+          knob: svaColors.brand.primary,
+          container: svaColors.bg.subtle,
+          header: svaColors.text.primary,
+          skinTonesContainer: svaColors.bg.elevated,
+          category: {
+            icon: svaColors.text.secondary,
+            iconActive: svaColors.brand.primary,
+            container: svaColors.bg.subtle,
+            containerActive: svaColors.bg.elevated,
+          },
+          search: {
+            background: svaColors.bg.elevated,
+            text: svaColors.text.primary,
+            placeholder: svaColors.text.disabled,
+            icon: svaColors.text.secondary,
+          },
+        }}
+      />
+
+      <TimePickerSheet
+        visible={isTimePickerOpen}
+        value={reminderTime}
+        title="Select time"
+        onChange={setReminderTime}
+        onClose={() => setIsTimePickerOpen(false)}
+      />
+
+      <StartDateModal
+        visible={isOriginPickerOpen}
+        onClose={() => setIsOriginPickerOpen(false)}
+        onSave={(value) => setOrigin(value)}
+        isEditMode={origin ?? undefined}
+        title="Genesis"
+        subtitle="Choose the origin point for this protocol."
+      />
+
+      <ProtocolTypePickerModal
+        visible={isProtocolTypeOpen}
+        onClose={() => setIsProtocolTypeOpen(false)}
+        title="Select Protocol Type"
+        types={protocolTypes}
+        selectedTypeId={selectedProtocolType?.id ?? null}
+        onSelect={(type) => setSelectedProtocolType(type)}
+      />
+
+      <HabitTagsModal
+        habitTagList={natureOptions}
+        visible={isNaturePickerOpen}
+        selectedTagData={natureTags}
+        title="Select Nature"
+        onClose={() => setIsNaturePickerOpen(false)}
+        onSelect={handleNatureTagSelect}
+      />
+
+      <ProtocolColorPickerModal
+        visible={isColorPickerOpen}
+        onClose={() => setIsColorPickerOpen(false)}
+        selectedColor={selectedColor}
+        onSelect={setSelectedColor}
+      />
+
+      <ProtocolUnitPickerModal
+        visible={isUnitPickerOpen}
+        onClose={() => setIsUnitPickerOpen(false)}
+        units={unitOptions}
+        selectedUnitId={metricUnit.id}
+        onSelect={(unit) => setMetricUnit(unit)}
+      />
+
+      <ProcessingModal
+        visible={isProcessingModalVisible}
+        title="Sealing Ritual"
+        subtitle="Your protocol is being prepared."
+        message="Please wait while we sync the backend and open the home screen."
+      />
+    </View>
+  );
+};
+
+const styling = (colors: any, typography: any, spacing: any) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.bg.base,
+    },
+    scrollContent: {
+      paddingBottom: 40,
+    },
+    screenView: {
+      paddingHorizontal: spacing.md,
+      paddingTop:
+        Platform.OS === "ios"
+          ? spacing.xl + spacing.xl * 0.4
+          : spacing.xl,
+    },
+    section: {
+      marginBottom: spacing.xl,
+    },
+    label: {
+      ...typography.textStyle.authTinyLabel,
+      color: colors.text.secondary,
+      marginBottom: spacing.sm,
+    },
+    nameInput: {
+      ...typography.textStyle.heading2,
+      color: colors.text.primary,
+      paddingVertical: spacing.md,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border.muted,
+      marginBottom: spacing.xl,
+    },
+    metricRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.md,
+      marginBottom: spacing.xl,
+    },
+    counterContainer: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: colors.bg.subtle,
+      borderRadius: 24,
+      padding: 4,
+      flex: 1,
+    },
+    counterBtn: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    counterValue: {
+      ...typography.textStyle.title,
+      color: colors.text.primary,
+      flex: 1,
+      textAlign: "center",
+    },
+    unitDropdown: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: colors.bg.subtle,
+      borderRadius: 24,
+      paddingHorizontal: spacing.lg,
+      height: 48,
+      gap: spacing.xs,
+    },
+    unitText: {
+      ...typography.textStyle.body,
+      color: colors.text.primary,
+    },
+    durationSection: {
+      alignItems: "flex-start",
+      marginBottom: spacing.xl,
+    },
+    durationChip: {
+      alignSelf: "flex-start",
+      backgroundColor: colors.bg.subtle,
+      borderRadius: 24,
+      paddingHorizontal: spacing.lg,
+      height: 48,
+      gap: spacing.xs,
+    },
+    reminderSection: {
+      alignItems: "flex-start",
+      marginBottom: spacing.xl,
+    },
+    reminderTrigger: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      alignSelf: "flex-start",
+      minWidth: 0,
+      backgroundColor: colors.bg.subtle,
+      borderRadius: 24,
+      paddingHorizontal: spacing.lg,
+      height: 48,
+      gap: spacing.xs,
+    },
+    reminderValue: {
+      ...typography.textStyle.body,
+      color: colors.text.primary,
+      fontWeight: "600",
+    },
+    divineCard: {
+      backgroundColor: colors.surface.base,
+      borderRadius: 24,
+      padding: spacing.lg,
+      marginBottom: spacing.xl,
+      borderWidth: 1,
+      borderColor: colors.border.subtle,
+    },
+    divineHeader: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.xs,
+      marginBottom: spacing.lg,
+    },
+    divineTitle: {
+      ...typography.textStyle.authTinyLabel,
+      color: colors.state.info,
+    },
+    gridContainer: {
+      flexDirection: "column",
+      gap: spacing.lg,
+    },
+    gridRow: {
+      flexDirection: "row",
+      gap: spacing.lg,
+    },
+    gridItem: {
+      flex: 1,
+    },
+    fullWidthItem: {
+      width: "100%",
+      flex: 0,
+    },
+    gridCompactBlock: {
+      width: "48%",
+      alignSelf: "flex-start",
+    },
+    gridCompactBlockWide: {
+      width: "100%",
+      alignSelf: "stretch",
+    },
+    natureChips: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      gap: spacing.xs,
+      marginTop: spacing.sm,
+    },
+    gridTileHeader: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      marginBottom: 6,
+    },
+    gridLabel: {
+      ...typography.textStyle.authTinyLabel,
+      color: colors.text.secondary,
+      marginBottom: 0,
+    },
+    gridValueRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.xs,
+    },
+    gridValueStack: {
+      alignItems: "flex-start",
+    },
+    gridEmoji: {
+      fontSize: typography.fontSize.md,
+    },
+    gridValueText: {
+      ...typography.textStyle.subtitle,
+      color: colors.text.primary,
+      fontWeight: "600",
+    },
+    gridValueSubtext: {
+      marginTop: 3,
+      ...typography.textStyle.caption,
+      color: colors.text.secondary,
+    },
+    colorDot: {
+      width: 14,
+      height: 14,
+      borderRadius: 7,
+    },
+    natureChip: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: colors.bg.subtle,
+      borderRadius: 999,
+      paddingHorizontal: spacing.md,
+      paddingVertical: 6,
+      gap: 6,
+    },
+    natureChipText: {
+      ...typography.textStyle.caption,
+      color: colors.text.primary,
+    },
+    buttonContainer: {
+      marginBottom: spacing.xl,
+    },
+    sealButton: {
+      backgroundColor: colors.brand.primary,
+      height: 56,
+      borderRadius: 16,
+      justifyContent: "center",
+      alignItems: "center",
+      shadowColor: colors.brand.primary,
+      shadowOffset: { width: 0, height: 4 },
+      shadowOpacity: 0.3,
+      shadowRadius: 8,
+      elevation: 5,
+    },
+    sealButtonText: {
+      ...typography.textStyle.button,
+      color: colors.text.inverse,
+      letterSpacing: 2,
+    },
+  });
+
+export default CreateProtocolScreen;

--- a/features/habit/utils/protocolDisplay.ts
+++ b/features/habit/utils/protocolDisplay.ts
@@ -1,0 +1,62 @@
+import type { HabitDateType } from "@/features/habit/types/habitTypes";
+
+const WEEKDAY_LABELS: Record<string, string> = {
+  su: "Sun",
+  mo: "Mon",
+  tu: "Tue",
+  we: "Wed",
+  th: "Thu",
+  fr: "Fri",
+  sa: "Sat",
+  sun: "Sun",
+  mon: "Mon",
+  tue: "Tue",
+  wed: "Wed",
+  thu: "Thu",
+  fri: "Fri",
+  sat: "Sat",
+};
+
+const normalizeWeekdayLabel = (value: string) => {
+  const key = value.trim().toLowerCase();
+  return WEEKDAY_LABELS[key] ?? value;
+};
+
+const pluralize = (value: number, singular: string) =>
+  value === 1 ? singular : `${singular}s`;
+
+export const formatProtocolFrequencySummary = (
+  protocolFrequency?: Pick<
+    HabitDateType,
+    "frequency_type" | "interval" | "days_of_week" | "days_of_month"
+  > | null
+) => {
+  const frequency = protocolFrequency?.frequency_type?.toLowerCase();
+  if (!frequency) return "";
+
+  const interval = Math.max(1, Number(protocolFrequency?.interval ?? 1));
+  const unit =
+    frequency === "daily"
+      ? pluralize(interval, "day")
+      : frequency === "weekly"
+      ? pluralize(interval, "week")
+      : pluralize(interval, "month");
+
+  const base = interval === 1 ? `Every ${unit}` : `Every ${interval} ${unit}`;
+
+  if (frequency === "weekly") {
+    const days = (protocolFrequency?.days_of_week ?? [])
+      .map(normalizeWeekdayLabel)
+      .filter(Boolean);
+    return days.length ? `${base} on ${days.join(", ")}` : base;
+  }
+
+  if (frequency === "monthly") {
+    const dates = (protocolFrequency?.days_of_month ?? []).filter(
+      (day): day is number => typeof day === "number" && Number.isFinite(day)
+    );
+    return dates.length ? `${base} on ${dates.join(", ")}` : base;
+  }
+
+  return base;
+};

--- a/utils/helper.ts
+++ b/utils/helper.ts
@@ -16,23 +16,28 @@ export function findIdBName(
   return foundItem ? foundItem[idKey] : undefined;
 }
 
-export const addObjectAtEnd = (data: any) => {
-  // Get the last object in the array
-  const lastObject = data[data.length - 1];
+export const addObjectAtEnd = (data: any[]) => {
+  const uniqueItems = Array.from(
+    new Map(data.map((item) => [item.id, item])).values()
+  );
 
-  // Extract the last id and increment it by 1
-  const newId = lastObject ? lastObject.id + 1 : 1; // Handle empty array case
+  const hasAddNew = uniqueItems.some((item) => item.name === "Add New");
+  if (hasAddNew) {
+    return uniqueItems;
+  }
 
-  // Create the new object to add
-  const newObject = {
-    id: newId,
-    name: "Add New",
-  };
+  const maxId = uniqueItems.reduce(
+    (max, item) => (typeof item.id === "number" ? Math.max(max, item.id) : max),
+    0
+  );
 
-  // Add the new object to the end of the array
-  const modifiedArray = [...data, newObject];
-
-  return modifiedArray;
+  return [
+    ...uniqueItems,
+    {
+      id: maxId + 1,
+      name: "Add New",
+    },
+  ];
 };
 
 export async function getDeviceDetails() {


### PR DESCRIPTION
## Summary
This PR refines the habit and protocol creation flow to follow the SVA modal and typography system end to end.

## What changed
- Added a dedicated protocol creation screen and route.
- Standardized protocol pickers and habit modals as bottom sheets with a shared header.
- Added a centered reusable processing modal for submit flows.
- Normalized start/end dates and times before sending to the backend so `Date` objects do not serialize as ISO strings.
- Cleaned the rhythm quick-window pills and other modal surfaces to use SVA typography and softer chip styling.
- Fixed tag list key collisions and renamed the recurrence summary helper to protocol terminology.

## Why
The previous flow mixed modal styles, used hardcoded type sizes in places, and let raw dates leak into the payload. This update makes the UI consistent and keeps backend payloads predictable.

## Validation
- `npx eslint` on the touched habit/protocol modal and screen files
