### PR TITLE
[codex] global premium gate

### DIFF
--- a/app/(auth)/(tabs)/settings.tsx
+++ b/app/(auth)/(tabs)/settings.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import ThemeContext from "@/contexts/ThemeContext";
 import { useAuth } from "@/contexts/AuthContext";
+import { getMembershipLabel } from "@/features/auth/utils/userEntitlements";
 import { ROUTES } from "@/constants/routes";
 import { SETTINGS_SECTIONS } from "@/constants/data/settingsList";
 import { SETTINGS_LAYOUT } from "@/features/settings/settingsLayout";
@@ -78,6 +79,11 @@ export default function SettingsScreen() {
     const handle = userProfile?.username?.trim();
     return `#${handle || "321be4"} glow active`;
   }, [userProfile]);
+
+  const membershipLabel = useMemo(
+    () => getMembershipLabel(userProfile),
+    [userProfile]
+  );
 
   useEffect(() => {
     if (!loc) return;
@@ -219,8 +225,8 @@ export default function SettingsScreen() {
           username={userProfile?.username || "321be4"}
           displayName={displayName}
           avatarUrl={userProfile?.avatar || null}
-          planLabel="PREMIUM MEMBER"
-          badgeLabel="PREMIUM MEMBER"
+          planLabel={membershipLabel}
+          badgeLabel={membershipLabel}
           statusLine={statusLine}
           onPressManagePlan={() => router.push(ROUTES.AUTH.BILLING_UPGRADE)}
         />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -26,6 +26,7 @@ import {
 } from "@expo-google-fonts/urbanist";
 
 import AuthProvider from "@/contexts/AuthContext";
+import { PremiumGateProvider } from "@/contexts/PremiumGateContext";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 // import HabitContext from "@/context/HabitContext";
 import { NimbusAlertProvider } from "@/components/ui/alert/NimbusAlertProvider";
@@ -76,17 +77,19 @@ function RootLayoutNav() {
   return (
     <AuthProvider>
       <ThemeProvider>
-        <NimbusAlertProvider>
-          {/* <HabitContext.Provider value={{ habitData, setHabitData }}> */}
-          <Stack screenOptions={{ headerShown: false }}>
-            {/* ✅ explicitly declare groups */}
-            <Stack.Screen name="(public)" />
-            <Stack.Screen name="(auth)" />
-          </Stack>
+        <PremiumGateProvider>
+          <NimbusAlertProvider>
+            {/* <HabitContext.Provider value={{ habitData, setHabitData }}> */}
+            <Stack screenOptions={{ headerShown: false }}>
+              {/* ✅ explicitly declare groups */}
+              <Stack.Screen name="(public)" />
+              <Stack.Screen name="(auth)" />
+            </Stack>
 
-          <NimbusToastHost />
-          {/* </HabitContext.Provider> */}
-        </NimbusAlertProvider>
+            <NimbusToastHost />
+            {/* </HabitContext.Provider> */}
+          </NimbusAlertProvider>
+        </PremiumGateProvider>
       </ThemeProvider>
     </AuthProvider>
   );

--- a/components/ui/modal/PremiumGateModal.tsx
+++ b/components/ui/modal/PremiumGateModal.tsx
@@ -1,0 +1,348 @@
+import React, { useContext, useMemo } from "react";
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
+
+import ThemeContext from "@/contexts/ThemeContext";
+import { NimbusButton } from "@/components/ui/theme-components/NimbusButton";
+import type { SvaColorSet, Spacing } from "@/theme/types";
+
+type PremiumGateModalTypography = {
+  titleFamily: string;
+  bodyFamily: string;
+  bodyStrongFamily: string;
+  monoFamily: string;
+};
+
+type PremiumGateModalProps = {
+  visible: boolean;
+  onClose: () => void;
+  onUpgrade: () => void;
+  title: string;
+  subtitle: string;
+  highlights: string[];
+  primaryLabel?: string;
+  secondaryLabel?: string;
+};
+
+export default function PremiumGateModal({
+  visible,
+  onClose,
+  onUpgrade,
+  title,
+  subtitle,
+  highlights,
+  primaryLabel = "Upgrade to Plus",
+  secondaryLabel = "Keep previewing",
+}: PremiumGateModalProps) {
+  const { svaColors, svaTypography, typography, spacing } =
+    useContext(ThemeContext);
+
+  const fonts = useMemo<PremiumGateModalTypography>(
+    () => ({
+      titleFamily:
+        svaTypography?.textStyle.authTitle.fontFamily ??
+        typography.h2.fontFamily ??
+        "CormorantGaramond_500Medium",
+      bodyFamily:
+        svaTypography?.textStyle.body.fontFamily ??
+        typography.body.fontFamily ??
+        "Outfit_400Regular",
+      bodyStrongFamily:
+        svaTypography?.textStyle.bodyMedium.fontFamily ??
+        typography.bodyStrong.fontFamily ??
+        "Outfit_600SemiBold",
+      monoFamily:
+        svaTypography?.textStyle.authMonoLabel.fontFamily ??
+        "SpaceMono-Regular",
+    }),
+    [svaTypography, typography]
+  );
+
+  const styles = useMemo(
+    () => createStyles(svaColors, fonts, spacing),
+    [svaColors, fonts, spacing]
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      statusBarTranslucent
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Dismiss premium preview"
+          onPress={onClose}
+          style={styles.backdrop}
+        />
+
+        <View style={styles.cardShell} pointerEvents="box-none">
+          <LinearGradient
+            colors={[
+              svaColors.brand.primary,
+              svaColors.surface.raised,
+              svaColors.surface.base,
+            ]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={styles.cardBorder}
+          >
+            <View style={styles.card}>
+              <View style={styles.handleRow}>
+                <View style={styles.handle} />
+              </View>
+
+              <View style={styles.heroRow}>
+                <View style={styles.iconWrap}>
+                  <Ionicons
+                    name="lock-closed"
+                    size={18}
+                    color={svaColors.brand.primary}
+                  />
+                </View>
+
+                <View style={styles.heroCopy}>
+                  <Text style={styles.eyebrow}>Premium preview</Text>
+                  <Text style={styles.title} numberOfLines={2}>
+                    {title}
+                  </Text>
+                  <Text style={styles.subtitle}>{subtitle}</Text>
+                </View>
+              </View>
+
+              <View style={styles.section}>
+                <View style={styles.sectionHeader}>
+                  <Text style={styles.sectionLabel}>What unlocks</Text>
+                  <Text style={styles.sectionMeta}>
+                    {String(highlights.length).padStart(2, "0")}
+                  </Text>
+                </View>
+
+                <ScrollView
+                  showsVerticalScrollIndicator={false}
+                  contentContainerStyle={styles.highlightList}
+                >
+                  {highlights.map((item) => (
+                    <View key={item} style={styles.highlightRow}>
+                      <View style={styles.checkBubble}>
+                        <Ionicons
+                          name="checkmark"
+                          size={13}
+                          color={svaColors.bg.base}
+                        />
+                      </View>
+                      <Text style={styles.highlightText}>{item}</Text>
+                    </View>
+                  ))}
+                </ScrollView>
+              </View>
+
+              <View style={styles.footer}>
+                <NimbusButton
+                  label={primaryLabel}
+                  onPress={onUpgrade}
+                  accessibilityLabel={primaryLabel}
+                  rightIcon={
+                    <Ionicons
+                      name="arrow-forward"
+                      size={18}
+                      color={svaColors.button.primary.text}
+                    />
+                  }
+                />
+
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={secondaryLabel}
+                  onPress={onClose}
+                  style={({ pressed }) => [
+                    styles.secondaryButton,
+                    pressed && styles.secondaryButtonPressed,
+                  ]}
+                >
+                  <Text style={styles.secondaryLabel}>{secondaryLabel}</Text>
+                </Pressable>
+              </View>
+            </View>
+          </LinearGradient>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function createStyles(
+  colors: SvaColorSet,
+  fonts: PremiumGateModalTypography,
+  spacing: Spacing
+) {
+  return StyleSheet.create({
+    overlay: {
+      flex: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      padding: spacing.lg,
+      backgroundColor: colors.overlay.strong,
+    },
+    backdrop: {
+      ...StyleSheet.absoluteFillObject,
+    },
+    cardShell: {
+      width: "100%",
+      maxWidth: 440,
+    },
+    cardBorder: {
+      borderRadius: 32,
+      padding: 1.5,
+      shadowColor: colors.shadow.default,
+      shadowOpacity: 0.3,
+      shadowRadius: 24,
+      shadowOffset: { width: 0, height: 12 },
+      elevation: 12,
+    },
+    card: {
+      borderRadius: 31,
+      paddingTop: spacing.xs,
+      paddingHorizontal: spacing.lg,
+      paddingBottom: spacing.lg,
+      backgroundColor: colors.bg.base,
+      borderWidth: 1,
+      borderColor: colors.border.subtle,
+    },
+    handleRow: {
+      alignItems: "center",
+      marginBottom: spacing.sm,
+    },
+    handle: {
+      width: 44,
+      height: 5,
+      borderRadius: 999,
+      backgroundColor: colors.border.muted,
+    },
+    heroRow: {
+      flexDirection: "row",
+      gap: spacing.md,
+      alignItems: "flex-start",
+      marginBottom: spacing.md,
+    },
+    iconWrap: {
+      width: 56,
+      height: 56,
+      borderRadius: 18,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: colors.brand.subtle,
+      borderWidth: 1,
+      borderColor: colors.border.muted,
+    },
+    heroCopy: {
+      flex: 1,
+    },
+    eyebrow: {
+      fontFamily: fonts.monoFamily,
+      color: colors.text.secondary,
+      fontSize: 10,
+      lineHeight: 12,
+      letterSpacing: 1.6,
+      textTransform: "uppercase",
+    },
+    title: {
+      marginTop: 4,
+      fontFamily: fonts.titleFamily,
+      color: colors.text.primary,
+      fontSize: 26,
+      lineHeight: 30,
+      letterSpacing: -0.4,
+    },
+    subtitle: {
+      marginTop: 6,
+      fontFamily: fonts.bodyFamily,
+      color: colors.text.secondary,
+      fontSize: 13,
+      lineHeight: 18,
+    },
+    section: {
+      marginBottom: spacing.md,
+      borderRadius: 24,
+      borderWidth: 1,
+      borderColor: colors.border.default,
+      backgroundColor: colors.surface.raised,
+      padding: spacing.md,
+    },
+    sectionHeader: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      marginBottom: spacing.sm,
+    },
+    sectionLabel: {
+      fontFamily: fonts.bodyStrongFamily,
+      color: colors.text.primary,
+      fontSize: 15,
+      lineHeight: 19,
+    },
+    sectionMeta: {
+      fontFamily: fonts.monoFamily,
+      color: colors.brand.primary,
+      fontSize: 10,
+      lineHeight: 12,
+      letterSpacing: 1.4,
+      textTransform: "uppercase",
+    },
+    highlightList: {
+      gap: spacing.sm,
+    },
+    highlightRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.sm,
+    },
+    checkBubble: {
+      width: 24,
+      height: 24,
+      borderRadius: 12,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: colors.brand.primary,
+    },
+    highlightText: {
+      flex: 1,
+      fontFamily: fonts.bodyFamily,
+      color: colors.text.primary,
+      fontSize: 13,
+      lineHeight: 18,
+    },
+    footer: {
+      gap: spacing.sm,
+    },
+    secondaryButton: {
+      alignItems: "center",
+      justifyContent: "center",
+      minHeight: 44,
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: colors.border.default,
+      backgroundColor: colors.surface.base,
+    },
+    secondaryButtonPressed: {
+      opacity: 0.84,
+    },
+    secondaryLabel: {
+      fontFamily: fonts.bodyStrongFamily,
+      color: colors.text.primary,
+      fontSize: 14,
+      lineHeight: 18,
+    },
+  });
+}

--- a/components/ui/modal/__tests__/PremiumGateModal.test.tsx
+++ b/components/ui/modal/__tests__/PremiumGateModal.test.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { Text } from "react-native";
+import renderer, { act } from "react-test-renderer";
+
+import ThemeContext from "../../../../contexts/ThemeContext";
+import { getTheme } from "../../../../theme";
+import PremiumGateModal from "../PremiumGateModal";
+
+jest.mock("expo-linear-gradient", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+
+  return {
+    LinearGradient: (props: any) => React.createElement(View, props),
+  };
+});
+
+jest.mock("../../theme-components/NimbusButton", () => {
+  const React = require("react");
+  const { Pressable, Text } = require("react-native");
+
+  return {
+    NimbusButton: ({ label, onPress, ...props }: any) =>
+      React.createElement(
+        Pressable,
+        { accessibilityLabel: label, onPress, ...props },
+        React.createElement(Text, null, label)
+      ),
+  };
+});
+
+const theme = getTheme("sva");
+const themeValue = {
+  theme: "sva",
+  toggleTheme: jest.fn(),
+  useSystemTheme: jest.fn(),
+  newTheme: theme.colors,
+  svaColors: theme.svaColors,
+  spacing: theme.spacing,
+  typography: theme.typography,
+  svaTypography: theme.svaTypography,
+  svaSpacing: theme.svaSpacing,
+  svaComponents: theme.svaComponents,
+  tokens: theme.tokens,
+  activeTheme: theme,
+};
+
+const getTextContent = (node: any) =>
+  Array.isArray(node.props.children)
+    ? node.props.children.join("")
+    : node.props.children;
+
+const hasText = (tree: renderer.ReactTestRenderer, value: string) =>
+  tree.root
+    .findAllByType(Text)
+    .some((node) => getTextContent(node) === value);
+
+function renderModal(
+  props: React.ComponentProps<typeof PremiumGateModal> = {} as any
+) {
+  let tree!: renderer.ReactTestRenderer;
+
+  act(() => {
+    tree = renderer.create(
+      <ThemeContext.Provider value={themeValue as any}>
+        <PremiumGateModal
+          visible
+          onClose={jest.fn()}
+          onUpgrade={jest.fn()}
+          title="Nimbus Plus required"
+          subtitle="Preview the manifest, then unlock the full stack."
+          highlights={[
+            "Full protocol stack and timing cues",
+            "Expanded context and reminders",
+            "Premium purchase flow",
+          ]}
+          {...props}
+        />
+      </ThemeContext.Provider>
+    );
+  });
+
+  return tree;
+}
+
+describe("PremiumGateModal", () => {
+  it("renders the purchase sheet copy and actions", () => {
+    const onClose = jest.fn();
+    const onUpgrade = jest.fn();
+    const tree = renderModal({ onClose, onUpgrade });
+
+    expect(hasText(tree, "Premium preview")).toBe(true);
+    expect(hasText(tree, "Nimbus Plus required")).toBe(true);
+    expect(hasText(tree, "Preview the manifest, then unlock the full stack.")).toBe(true);
+    expect(hasText(tree, "Full protocol stack and timing cues")).toBe(true);
+    expect(hasText(tree, "Expanded context and reminders")).toBe(true);
+    expect(hasText(tree, "Premium purchase flow")).toBe(true);
+
+    const upgradeButton = tree.root.findByProps({
+      accessibilityLabel: "Upgrade to Plus",
+    });
+    const dismissButton = tree.root.findByProps({
+      accessibilityLabel: "Keep previewing",
+    });
+
+    act(() => {
+      upgradeButton.props.onPress();
+    });
+    act(() => {
+      dismissButton.props.onPress();
+    });
+
+    expect(onUpgrade).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -13,6 +13,10 @@ import axios from "axios";
 import { StoreKey } from "@/constants/Constant";
 import { ROUTES } from "@/constants/routes";
 import {
+  normalizeUserProfile,
+} from "@/features/auth/utils/userEntitlements";
+import type { UserProfile } from "@/features/auth/types/userProfile";
+import {
   login,
   signup,
   logout,
@@ -31,20 +35,6 @@ export async function clearAuthAndOnboarding() {
 const resetApp = async () => {
   await clearAuthAndOnboarding();
   router.replace(ROUTES.PUBLIC.LANDING);
-};
-
-type UserProfile = {
-  full_name?: string | null;
-  phone_number?: string | null;
-  id: number;
-  avatar?: string | null;
-  username: string | null;
-  email: string | null;
-  first_name: string | null;
-  last_name: string | null;
-  profile: any;
-  settings: any;
-  // add whatever fields your API returns
 };
 
 // Cache Token Key
@@ -212,7 +202,11 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
           axios.defaults.headers.common["Authorization"] = `Bearer ${token}`;
           setAuthState({ token, authenticated: true });
 
-          if (profileInfo) setUserProfile(JSON.parse(profileInfo));
+          if (profileInfo) {
+            // Temporary entitlement seed: default to a free profile until the backend sends tier data consistently.
+            const cachedProfile = normalizeUserProfile(JSON.parse(profileInfo));
+            if (cachedProfile) setUserProfile(cachedProfile);
+          }
           // ✅ If key missing, decide a default (recommended: false)
           setOnboardingDone(ob === "true");
         } else {
@@ -411,7 +405,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
           notifications,
           ...tokens
         } = data;
-        const usr = {
+        const usr = normalizeUserProfile({
           id: id,
           avatar: data.avatar || null,
           username: username,
@@ -421,8 +415,10 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
           profile: profile,
           settings: settings,
           notifications: notifications,
-        };
-        await applyServerUser(usr);
+        });
+        if (usr) {
+          await applyServerUser(usr as any);
+        }
         // const profileInfo = await SecureStore.getItem(USER_PROFILE_KEY);
         await SecureStore.setItemAsync(USER_PROFILE_KEY, JSON.stringify(usr));
         setUserProfile(usr);
@@ -454,7 +450,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
             notifications,
             notification_preferences,
           } = data;
-          const usr = {
+          const usr = normalizeUserProfile({
             id: id,
             username: username,
             email: email,
@@ -464,8 +460,10 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
             profile: profile,
             settings: settings,
             notifications: notifications,
-          };
-          await applyServerUser(usr); // keep app + storage in sync
+          });
+          await applyServerUser(usr as any); // keep app + storage in sync
+          await SecureStore.setItemAsync(USER_PROFILE_KEY, JSON.stringify(usr));
+          setUserProfile(usr);
         }
         return res; // caller decides what to do
       } catch (err: any) {

--- a/contexts/PremiumGateContext.tsx
+++ b/contexts/PremiumGateContext.tsx
@@ -1,0 +1,133 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { router } from "expo-router";
+
+import PremiumGateModal from "@/components/ui/modal/PremiumGateModal";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  PREMIUM_GATE_CONFIG,
+  getPremiumGateState,
+  type PremiumGateConfig,
+  type PremiumGateFeatureKey,
+  type PremiumGateSource,
+  type PremiumGateState,
+} from "@/features/entitlements/premiumGates";
+
+type PremiumGateRequest = {
+  featureKey: PremiumGateFeatureKey;
+  source: PremiumGateSource;
+};
+
+type PremiumGateContextValue = {
+  openGate: (
+    featureKey: PremiumGateFeatureKey,
+    source?: PremiumGateSource
+  ) => void;
+  closeGate: () => void;
+  getAccessState: (featureKey: PremiumGateFeatureKey) => PremiumGateState;
+  canAccess: (featureKey: PremiumGateFeatureKey) => boolean;
+  activeGate: PremiumGateRequest | null;
+};
+
+const PremiumGateContext = createContext<PremiumGateContextValue | null>(null);
+
+export function usePremiumGate() {
+  const context = useContext(PremiumGateContext);
+
+  if (!context) {
+    throw new Error("usePremiumGate must be used within a <PremiumGateProvider />");
+  }
+
+  return context;
+}
+
+type PremiumGateProviderProps = {
+  children: ReactNode;
+};
+
+export function PremiumGateProvider({ children }: PremiumGateProviderProps) {
+  const { userProfile } = useAuth();
+  const [activeGate, setActiveGate] = useState<PremiumGateRequest | null>(null);
+
+  const getAccessState = useCallback(
+    (featureKey: PremiumGateFeatureKey) =>
+      getPremiumGateState(featureKey, userProfile),
+    [userProfile]
+  );
+
+  const canAccess = useCallback(
+    (featureKey: PremiumGateFeatureKey) => getAccessState(featureKey) === "allowed",
+    [getAccessState]
+  );
+
+  const closeGate = useCallback(() => {
+    setActiveGate(null);
+  }, []);
+
+  const openGate = useCallback(
+    (featureKey: PremiumGateFeatureKey, source: PremiumGateSource = "cta_press") => {
+      if (getAccessState(featureKey) === "allowed") return;
+      setActiveGate({ featureKey, source });
+    },
+    [getAccessState]
+  );
+
+  useEffect(() => {
+    if (!activeGate) return;
+    // Close the sheet if the user upgrades while it is open.
+    if (getAccessState(activeGate.featureKey) === "allowed") {
+      setActiveGate(null);
+    }
+  }, [activeGate, getAccessState]);
+
+  const activeConfig: PremiumGateConfig | null = useMemo(() => {
+    if (!activeGate) return null;
+    return PREMIUM_GATE_CONFIG[activeGate.featureKey];
+  }, [activeGate]);
+
+  const handleUpgrade = useCallback(() => {
+    if (!activeConfig) return;
+
+    closeGate();
+    router.push(activeConfig.upgradeRoute);
+  }, [activeConfig, closeGate]);
+
+  const contextValue = useMemo<PremiumGateContextValue>(
+    () => ({
+      openGate,
+      closeGate,
+      getAccessState,
+      canAccess,
+      activeGate,
+    }),
+    [activeGate, canAccess, closeGate, getAccessState, openGate]
+  );
+
+  return (
+    <PremiumGateContext.Provider value={contextValue}>
+      {children}
+
+      {/* Single global paywall sheet for the whole app. */}
+      <PremiumGateModal
+        visible={!!activeConfig}
+        onClose={closeGate}
+        onUpgrade={handleUpgrade}
+        title={activeConfig?.title ?? "Nimbus Plus required"}
+        subtitle={
+          activeConfig?.subtitle ??
+          "Upgrade to unlock this experience."
+        }
+        highlights={activeConfig?.highlights ?? []}
+        primaryLabel={activeConfig?.primaryLabel ?? "Upgrade to Plus"}
+        secondaryLabel={activeConfig?.secondaryLabel ?? "Keep previewing"}
+      />
+    </PremiumGateContext.Provider>
+  );
+}

--- a/contexts/__tests__/PremiumGateContext.test.tsx
+++ b/contexts/__tests__/PremiumGateContext.test.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+import { Pressable, Text, View } from "react-native";
+import renderer, { act } from "react-test-renderer";
+
+import { ROUTES } from "@/constants/routes";
+import {
+  MOCK_FREE_USER_PROFILE,
+  MOCK_PLUS_USER_PROFILE,
+} from "@/features/auth/data/mockUserProfiles";
+import type { UserProfile } from "@/features/auth/types/userProfile";
+
+import { PremiumGateProvider, usePremiumGate } from "../PremiumGateContext";
+
+const mockPush = jest.fn();
+
+let mockUserProfile: UserProfile | null = MOCK_FREE_USER_PROFILE;
+
+jest.mock("expo-router", () => ({
+  router: {
+    push: (...args: any[]) => mockPush(...args),
+  },
+}));
+
+jest.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    userProfile: mockUserProfile,
+  }),
+}));
+
+jest.mock("@/components/ui/modal/PremiumGateModal", () => {
+  const React = require("react");
+  const { Pressable, Text, View } = require("react-native");
+
+  return function MockPremiumGateModal(props: any) {
+    if (!props.visible) return null;
+
+    return React.createElement(
+      View,
+      null,
+      React.createElement(Text, null, props.title),
+      React.createElement(Text, null, props.subtitle),
+      React.createElement(Text, null, props.primaryLabel),
+      React.createElement(Text, null, props.secondaryLabel),
+      React.createElement(
+        Pressable,
+        { accessibilityLabel: "gate-upgrade", onPress: props.onUpgrade },
+        React.createElement(Text, null, "Upgrade")
+      ),
+      React.createElement(
+        Pressable,
+        { accessibilityLabel: "gate-close", onPress: props.onClose },
+        React.createElement(Text, null, "Close")
+      )
+    );
+  };
+});
+
+const getTextContent = (node: any) =>
+  Array.isArray(node.props.children)
+    ? node.props.children.join("")
+    : node.props.children;
+
+const hasText = (tree: renderer.ReactTestRenderer, value: string) =>
+  tree.root.findAllByType(Text).some((node) => getTextContent(node) === value);
+
+function GateHarness() {
+  const { openGate, getAccessState, activeGate, canAccess } = usePremiumGate();
+
+  return (
+    <View>
+      <Text>{getAccessState("curated_manifest_detail")}</Text>
+      <Text>{String(canAccess("curated_manifest_detail"))}</Text>
+      <Text>{activeGate?.featureKey ?? "none"}</Text>
+
+      <Pressable
+        accessibilityLabel="open-detail-gate"
+        onPress={() => openGate("curated_manifest_detail", "screen_entry")}
+      >
+        <Text>Open detail gate</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function renderHarness() {
+  let tree!: renderer.ReactTestRenderer;
+
+  act(() => {
+    tree = renderer.create(
+      <PremiumGateProvider>
+        <GateHarness />
+      </PremiumGateProvider>
+    );
+  });
+
+  return tree;
+}
+
+describe("PremiumGateContext", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUserProfile = MOCK_FREE_USER_PROFILE;
+  });
+
+  it("opens the shared gate for free users and dismisses cleanly", () => {
+    const tree = renderHarness();
+
+    expect(hasText(tree, "preview")).toBe(true);
+    expect(hasText(tree, "false")).toBe(true);
+    expect(hasText(tree, "none")).toBe(true);
+
+    act(() => {
+      tree.root.findByProps({
+        accessibilityLabel: "open-detail-gate",
+      }).props.onPress();
+    });
+
+    expect(hasText(tree, "curated_manifest_detail")).toBe(true);
+    expect(hasText(tree, "Nimbus Plus required")).toBe(true);
+    expect(hasText(tree, "Upgrade to Plus")).toBe(true);
+
+    act(() => {
+      tree.root.findByProps({
+        accessibilityLabel: "gate-close",
+      }).props.onPress();
+    });
+
+    expect(hasText(tree, "Nimbus Plus required")).toBe(false);
+    expect(hasText(tree, "curated_manifest_detail")).toBe(false);
+  });
+
+  it("routes to billing from the shared gate upgrade action", () => {
+    const tree = renderHarness();
+
+    act(() => {
+      tree.root.findByProps({
+        accessibilityLabel: "open-detail-gate",
+      }).props.onPress();
+    });
+
+    act(() => {
+      tree.root.findByProps({
+        accessibilityLabel: "gate-upgrade",
+      }).props.onPress();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith(ROUTES.AUTH.BILLING_UPGRADE);
+  });
+
+  it("does not open the gate for premium users", () => {
+    mockUserProfile = MOCK_PLUS_USER_PROFILE;
+
+    const tree = renderHarness();
+
+    expect(hasText(tree, "allowed")).toBe(true);
+    expect(hasText(tree, "true")).toBe(true);
+
+    act(() => {
+      tree.root.findByProps({
+        accessibilityLabel: "open-detail-gate",
+      }).props.onPress();
+    });
+
+    expect(hasText(tree, "Nimbus Plus required")).toBe(false);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/features/auth/data/mockUserProfiles.ts
+++ b/features/auth/data/mockUserProfiles.ts
@@ -1,0 +1,45 @@
+import type { UserProfile } from "../types/userProfile";
+
+const buildMockUserProfile = (tier: "free" | "plus"): UserProfile => ({
+  id: tier === "plus" ? 902 : 901,
+  username: tier === "plus" ? "nimbus.plus" : "nimbus.free",
+  email: tier === "plus" ? "plus@nimbus.dev" : "free@nimbus.dev",
+  full_name: tier === "plus" ? "Nimbus Plus Member" : "Nimbus Free Member",
+  first_name: tier === "plus" ? "Nimbus" : "Free",
+  last_name: tier === "plus" ? "Plus" : "Member",
+  avatar: null,
+  profile: {
+    phone_number: null,
+    height: null,
+    weight: null,
+    age: null,
+    gender: null,
+  },
+  settings: {
+    liquid_unit: "ml",
+    height_unit: "cm",
+    weight_unit: "kg",
+    weather_unit: "celsius",
+    start_of_day: "06:00",
+    start_of_week: "monday",
+    sleep_time: "22:00",
+    location: null,
+  },
+  address: {
+    street: null,
+    city: null,
+    state: null,
+    zip_code: null,
+    country: null,
+  },
+  notifications: [],
+  subscription: {
+    tier,
+    status: "active",
+    source: "mock",
+  },
+});
+
+// Temporary fixtures until the backend returns a subscription payload for every profile.
+export const MOCK_FREE_USER_PROFILE = buildMockUserProfile("free");
+export const MOCK_PLUS_USER_PROFILE = buildMockUserProfile("plus");

--- a/features/auth/services/loginService.ts
+++ b/features/auth/services/loginService.ts
@@ -18,58 +18,7 @@ import {
   SetPasswordResponse,
   SetPasswordRequest,
 } from "@/features/auth/types/loginTypes";
-
-type UserProfile = {
-  full_name?: string | null;
-  // phone_number?: string | null;
-  id: number;
-  username: string;
-  email: string;
-  first_name: string | null;
-  last_name: string | null;
-  avatar: string | null;
-  profile: {
-    phone_number: string | null;
-    height: number | string | null;
-    weight: number | string | null;
-    age: number | null;
-    gender: string | null;
-  };
-  settings: {
-    weight_unit?: "kg" | "lbs";
-    height_unit?: "cm" | "in";
-    liquid_unit?: "ml" | "oz";
-    weather_unit?: "celsius" | "fahrenheit";
-    start_of_day?: string | null; // "06:00"
-    start_of_week?: "monday" | "sunday";
-    sleep_time?: string | null;
-    location?: string | null;
-    // weight_unit: string | null;
-    // height_unit: string | null;
-    // liquid_unit: string | null;
-    // weather_unit: string | null;
-    // start_of_day: string | null;
-    // start_of_week: string | null;
-    // sleep_time: string | null;
-    // location: string | null;
-  };
-  address: {
-    street: string | null;
-    city: string | null;
-    state: string | null;
-    zip_code: string | null;
-    country: string | null;
-  };
-  notifications: [
-    {
-      notification_type: string;
-      enabled: true;
-      time: string;
-      days_of_week: string[];
-    }
-  ];
-  // add whatever fields your API returns
-};
+import type { UserProfile } from "@/features/auth/types/userProfile";
 
 type FetchUserResponse = {
   success: boolean;

--- a/features/auth/types/userProfile.ts
+++ b/features/auth/types/userProfile.ts
@@ -1,0 +1,31 @@
+export type UserSubscriptionTier = "free" | "plus";
+
+export type UserSubscription = {
+  tier: UserSubscriptionTier;
+  status?: "active" | "trial" | "inactive";
+  source?: "api" | "mock";
+  expires_at?: string | null;
+};
+
+export type UserNotification = {
+  notification_type: string;
+  enabled: boolean;
+  time: string;
+  days_of_week: string[];
+};
+
+export type UserProfile = {
+  id: number;
+  username: string | null;
+  email: string | null;
+  full_name?: string | null;
+  phone_number?: string | null;
+  first_name?: string | null;
+  last_name?: string | null;
+  avatar?: string | null;
+  profile?: Record<string, unknown> | null;
+  settings?: Record<string, unknown> | null;
+  address?: Record<string, unknown> | null;
+  notifications?: UserNotification[];
+  subscription?: UserSubscription | null;
+};

--- a/features/auth/utils/__tests__/userEntitlements.test.ts
+++ b/features/auth/utils/__tests__/userEntitlements.test.ts
@@ -1,0 +1,35 @@
+import {
+  MOCK_FREE_USER_PROFILE,
+  MOCK_PLUS_USER_PROFILE,
+} from "@/features/auth/data/mockUserProfiles";
+import {
+  getMembershipLabel,
+  hasPremiumAccess,
+  normalizeUserProfile,
+} from "../userEntitlements";
+
+describe("userEntitlements", () => {
+  it("seeds a mock free subscription when the profile does not include tier data", () => {
+    const profile = normalizeUserProfile({
+      id: 123,
+      username: "demo",
+      email: "demo@nimbus.dev",
+      first_name: "Demo",
+      last_name: "User",
+      avatar: null,
+      profile: {},
+      settings: {},
+      notifications: [],
+    });
+
+    expect(profile?.subscription?.tier).toBe("free");
+    expect(profile?.subscription?.source).toBe("mock");
+  });
+
+  it("maps user profiles to the expected membership labels", () => {
+    expect(hasPremiumAccess(MOCK_FREE_USER_PROFILE)).toBe(false);
+    expect(hasPremiumAccess(MOCK_PLUS_USER_PROFILE)).toBe(true);
+    expect(getMembershipLabel(MOCK_FREE_USER_PROFILE)).toBe("FREE MEMBER");
+    expect(getMembershipLabel(MOCK_PLUS_USER_PROFILE)).toBe("PREMIUM MEMBER");
+  });
+});

--- a/features/auth/utils/userEntitlements.ts
+++ b/features/auth/utils/userEntitlements.ts
@@ -1,0 +1,35 @@
+import type {
+  UserProfile,
+  UserSubscription,
+  UserSubscriptionTier,
+} from "@/features/auth/types/userProfile";
+
+const FALLBACK_SUBSCRIPTION = {
+  tier: "free",
+  status: "active",
+  source: "mock",
+  expires_at: null,
+} satisfies UserSubscription;
+
+export const normalizeUserProfile = (
+  profile: UserProfile | null | undefined
+): UserProfile | null => {
+  if (!profile) return null;
+
+  return {
+    ...profile,
+    subscription: profile.subscription ?? FALLBACK_SUBSCRIPTION,
+  };
+};
+
+export const getUserTier = (
+  profile: UserProfile | null | undefined
+): UserSubscriptionTier => profile?.subscription?.tier ?? "free";
+
+export const hasPremiumAccess = (
+  profile: UserProfile | null | undefined
+) => getUserTier(profile) === "plus";
+
+export const getMembershipLabel = (
+  profile: UserProfile | null | undefined
+) => (hasPremiumAccess(profile) ? "PREMIUM MEMBER" : "FREE MEMBER");

--- a/features/entitlements/premiumGates.ts
+++ b/features/entitlements/premiumGates.ts
@@ -1,0 +1,68 @@
+import { ROUTES } from "@/constants/routes";
+import type { UserProfile } from "@/features/auth/types/userProfile";
+import { hasPremiumAccess } from "@/features/auth/utils/userEntitlements";
+
+export type PremiumGateFeatureKey =
+  | "curated_manifest_detail"
+  | "curated_manifest_protocols";
+
+export type PremiumGateMode = "preview" | "locked";
+export type PremiumGateState = "allowed" | PremiumGateMode;
+export type PremiumGateSource =
+  | "screen_entry"
+  | "cta_press"
+  | "card_tap"
+  | "row_tap";
+
+export type PremiumGateConfig = {
+  featureKey: PremiumGateFeatureKey;
+  mode: PremiumGateMode;
+  title: string;
+  subtitle: string;
+  highlights: string[];
+  primaryLabel: string;
+  secondaryLabel: string;
+  upgradeRoute: (typeof ROUTES)["AUTH"]["BILLING_UPGRADE"];
+};
+
+export const PREMIUM_GATE_CONFIG: Record<PremiumGateFeatureKey, PremiumGateConfig> =
+  {
+    curated_manifest_detail: {
+      featureKey: "curated_manifest_detail",
+      mode: "preview",
+      title: "Nimbus Plus required",
+      subtitle:
+        "You can preview the manifest here. Upgrade to Plus to unlock the full protocol stack and premium notes.",
+      highlights: [
+        "Full protocol stack and timing cues",
+        "Expanded context, benefits, and reminders",
+        "Access to premium purchase flow",
+      ],
+      primaryLabel: "Upgrade to Plus",
+      secondaryLabel: "Keep previewing",
+      upgradeRoute: ROUTES.AUTH.BILLING_UPGRADE,
+    },
+    curated_manifest_protocols: {
+      featureKey: "curated_manifest_protocols",
+      mode: "locked",
+      title: "Protocol stack locked",
+      subtitle:
+        "The stack for this manifest is part of Nimbus Plus. Unlock the plan to open the full sequence.",
+      highlights: [
+        "Full protocol stack and timing cues",
+        "Premium scheduling guidance",
+        "Access to premium purchase flow",
+      ],
+      primaryLabel: "Upgrade to Plus",
+      secondaryLabel: "Keep previewing",
+      upgradeRoute: ROUTES.AUTH.BILLING_UPGRADE,
+    },
+  };
+
+export const getPremiumGateState = (
+  featureKey: PremiumGateFeatureKey,
+  profile: UserProfile | null | undefined
+): PremiumGateState => {
+  if (hasPremiumAccess(profile)) return "allowed";
+  return PREMIUM_GATE_CONFIG[featureKey].mode;
+};

--- a/features/tools/screens/CuratedManifestDetailScreen.tsx
+++ b/features/tools/screens/CuratedManifestDetailScreen.tsx
@@ -1,4 +1,9 @@
-import React, { useContext, useEffect, useMemo } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+} from "react";
 import {
   ScrollView,
   Share,
@@ -20,6 +25,7 @@ import {
   getCuratedManifestById,
   type CuratedManifest,
 } from "@/features/tools/data/curatedManifests";
+import { usePremiumGate } from "@/contexts/PremiumGateContext";
 import ManifestHero from "@/features/tools/components/curated-manifest-detail/ManifestHero";
 import ManifestStatGrid from "@/features/tools/components/curated-manifest-detail/ManifestStatGrid";
 import ManifestSection from "@/features/tools/components/curated-manifest-detail/ManifestSection";
@@ -36,6 +42,7 @@ export const CuratedManifestDetailScreen: React.FC = () => {
   const params = useLocalSearchParams<{ id?: string | string[] }>();
   const insets = useSafeAreaInsets();
   const { svaColors, spacing, svaTypography } = useContext(ThemeContext);
+  const { openGate, getAccessState } = usePremiumGate();
   const styles = styling(svaColors, spacing, svaTypography, insets.bottom);
 
   const idParam = getStringParam(params.id);
@@ -50,6 +57,35 @@ export const CuratedManifestDetailScreen: React.FC = () => {
       CURATED_MANIFESTS[0]
     );
   }, [idParam]);
+
+  const accessState = getAccessState("curated_manifest_detail");
+  const hasPremium = accessState === "allowed";
+
+  useEffect(() => {
+    // Show the shared gate once when a free user lands on the detail screen.
+    if (accessState === "preview") {
+      openGate("curated_manifest_detail", "screen_entry");
+    }
+  }, [accessState, idParam, openGate]);
+
+  const handleProtocolStackPress = useCallback(() => {
+    if (!hasPremium) {
+      openGate("curated_manifest_protocols", "cta_press");
+      return;
+    }
+
+    router.push({
+      pathname: ROUTES.AUTH.TOOLS_CURATED_MANIFEST_PROTOCOLS,
+      params: { id: manifest.id },
+    });
+  }, [hasPremium, manifest.id, openGate]);
+
+  const ctaLabel = hasPremium
+    ? "View Protocol Stack"
+    : "Unlock Protocol Stack";
+  const ctaHint = hasPremium
+    ? "Opens the protocol stack"
+    : "Opens the upgrade modal";
 
   const onShare = async () => {
     try {
@@ -113,16 +149,12 @@ export const CuratedManifestDetailScreen: React.FC = () => {
 
       <View style={styles.footerDock}>
         <NimbusButton
-          label="View Protocol Stack"
-          onPress={() =>
-            router.push({
-              pathname: ROUTES.AUTH.TOOLS_CURATED_MANIFEST_PROTOCOLS,
-              params: { id: manifest.id },
-            })
-          }
+          label={ctaLabel}
+          onPress={handleProtocolStackPress}
+          accessibilityHint={ctaHint}
           rightIcon={
             <Ionicons
-              name="arrow-forward"
+              name={hasPremium ? "arrow-forward" : "lock-closed"}
               size={18}
               color={svaColors.button.primary.text}
             />

--- a/features/tools/screens/__tests__/CuratedManifestDetailScreen.test.tsx
+++ b/features/tools/screens/__tests__/CuratedManifestDetailScreen.test.tsx
@@ -1,0 +1,244 @@
+import React from "react";
+import { Text, View } from "react-native";
+import renderer, { act } from "react-test-renderer";
+
+import ThemeContext from "../../../../contexts/ThemeContext";
+import { ROUTES } from "../../../../constants/routes";
+import { getTheme } from "../../../../theme";
+import CuratedManifestDetailScreen from "../CuratedManifestDetailScreen";
+
+const mockPush = jest.fn();
+const mockBack = jest.fn();
+const mockSetOptions = jest.fn();
+const mockOpenGate = jest.fn();
+
+const mockNavigation = {
+  setOptions: mockSetOptions,
+};
+
+let mockAccessState: "preview" | "locked" | "allowed" = "preview";
+let mockParams = { id: "agni-reset" };
+
+jest.mock("expo-router", () => ({
+  router: {
+    push: (...args: any[]) => mockPush(...args),
+    back: (...args: any[]) => mockBack(...args),
+  },
+  useNavigation: () => mockNavigation,
+  useLocalSearchParams: () => mockParams,
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock("../../../../contexts/PremiumGateContext", () => ({
+  usePremiumGate: () => ({
+    openGate: (...args: any[]) => mockOpenGate(...args),
+    closeGate: jest.fn(),
+    getAccessState: () => mockAccessState,
+    canAccess: () => mockAccessState === "allowed",
+    activeGate: null,
+  }),
+}));
+
+jest.mock("../../../../components/ui/Themed", () => ({
+  ScreenView: ({ children, ...props }: any) => {
+    const React = require("react");
+    const { View } = require("react-native");
+
+    return React.createElement(View, props, children);
+  },
+}));
+
+jest.mock("../../../../components/layout/ScreenHeader", () => ({
+  __esModule: true,
+  default: ({ title }: any) => {
+    const React = require("react");
+    const { Text } = require("react-native");
+
+    return React.createElement(Text, null, title);
+  },
+}));
+
+jest.mock("../../../../components/ui/theme-components/NimbusButton", () => {
+  const React = require("react");
+  const { Pressable, Text } = require("react-native");
+
+  return {
+    NimbusButton: ({ label, onPress, ...props }: any) =>
+      React.createElement(
+        Pressable,
+        { accessibilityLabel: label, onPress, ...props },
+        React.createElement(Text, null, label)
+      ),
+  };
+});
+
+jest.mock(
+  "../../../../features/tools/components/curated-manifest-detail/ManifestHero",
+  () => ({
+    __esModule: true,
+    default: ({ title }: any) => {
+      const React = require("react");
+      const { Text } = require("react-native");
+
+      return React.createElement(Text, null, title);
+    },
+  })
+);
+
+jest.mock(
+  "../../../../features/tools/components/curated-manifest-detail/ManifestStatGrid",
+  () => ({
+    __esModule: true,
+    default: ({ items }: any) => {
+      const React = require("react");
+      const { Text, View } = require("react-native");
+
+      return React.createElement(
+        View,
+        null,
+        items.map((item: any) =>
+          React.createElement(Text, { key: item.label }, item.label)
+        )
+      );
+    },
+  })
+);
+
+jest.mock(
+  "../../../../features/tools/components/curated-manifest-detail/ManifestSection",
+  () => ({
+    __esModule: true,
+    default: ({ title, children }: any) => {
+      const React = require("react");
+      const { Text, View } = require("react-native");
+
+      return React.createElement(
+        View,
+        null,
+        React.createElement(Text, null, title),
+        children
+      );
+    },
+  })
+);
+
+jest.mock(
+  "../../../../features/tools/components/curated-manifest-detail/BenefitList",
+  () => ({
+    __esModule: true,
+    default: ({ items }: any) => {
+      const React = require("react");
+      const { Text, View } = require("react-native");
+
+      return React.createElement(
+        View,
+        null,
+        items.map((item: string) =>
+          React.createElement(Text, { key: item }, item)
+        )
+      );
+    },
+  })
+);
+
+const theme = getTheme("sva");
+const themeValue = {
+  theme: "sva",
+  toggleTheme: jest.fn(),
+  useSystemTheme: jest.fn(),
+  newTheme: theme.colors,
+  svaColors: theme.svaColors,
+  spacing: theme.spacing,
+  typography: theme.typography,
+  svaTypography: theme.svaTypography,
+  svaSpacing: theme.svaSpacing,
+  svaComponents: theme.svaComponents,
+  tokens: theme.tokens,
+  activeTheme: theme,
+};
+
+const getTextContent = (node: any) =>
+  Array.isArray(node.props.children)
+    ? node.props.children.join("")
+    : node.props.children;
+
+const hasText = (tree: renderer.ReactTestRenderer, value: string) =>
+  tree.root
+    .findAllByType(Text)
+    .some((node) => getTextContent(node) === value);
+
+function renderScreen() {
+  let tree!: renderer.ReactTestRenderer;
+
+  act(() => {
+    tree = renderer.create(
+      <ThemeContext.Provider value={themeValue as any}>
+        <CuratedManifestDetailScreen />
+      </ThemeContext.Provider>
+    );
+  });
+
+  return tree;
+}
+
+describe("CuratedManifestDetailScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams = { id: "agni-reset" };
+    mockAccessState = "preview";
+  });
+
+  it("opens the gate on entry for preview users and opens the locked modal from the CTA", () => {
+    const tree = renderScreen();
+
+    expect(mockSetOptions).toHaveBeenCalledWith({
+      headerShown: false,
+    });
+    expect(mockOpenGate).toHaveBeenCalledWith(
+      "curated_manifest_detail",
+      "screen_entry"
+    );
+    expect(hasText(tree, "Unlock Protocol Stack")).toBe(true);
+
+    const ctaButton = tree.root.findByProps({
+      accessibilityLabel: "Unlock Protocol Stack",
+    });
+
+    act(() => {
+      ctaButton.props.onPress();
+    });
+
+    expect(mockOpenGate).toHaveBeenCalledWith(
+      "curated_manifest_protocols",
+      "cta_press"
+    );
+  });
+
+  it("routes directly to the protocol stack for premium users", () => {
+    mockAccessState = "allowed";
+
+    const tree = renderScreen();
+
+    expect(mockOpenGate).not.toHaveBeenCalledWith(
+      "curated_manifest_detail",
+      "screen_entry"
+    );
+    expect(hasText(tree, "View Protocol Stack")).toBe(true);
+
+    const ctaButton = tree.root.findByProps({
+      accessibilityLabel: "View Protocol Stack",
+    });
+
+    act(() => {
+      ctaButton.props.onPress();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: ROUTES.AUTH.TOOLS_CURATED_MANIFEST_PROTOCOLS,
+      params: { id: "agni-reset" },
+    });
+  });
+});


### PR DESCRIPTION
## What changed
- Added a global `PremiumGateProvider` at the app root so the paywall modal is mounted once and shared across the app.
- Introduced a reusable `PremiumGateModal` and centralized entitlement rules for curated manifest access.
- Added mock `userProfile.subscription.tier` support plus helpers to normalize free vs plus profiles.
- Updated curated manifest detail so free users can preview the screen and trigger the shared premium gate.
- Added tests for the modal, provider wiring, curated manifest behavior, and entitlement helpers.

## Why
- The previous approach scattered gate logic across screens.
- The app now needs a single source of truth for free vs premium access so locked content can reuse the same UX and billing flow.

## Impact
- Free users can still enter the curated manifest detail screen, but locked actions open the shared premium modal.
- Premium users bypass the gate and continue directly to the protocol stack.
- The implementation is modular, so future locked features can call the same hook without adding modal JSX to each screen.

## Validation
- `npx eslint --quiet contexts/PremiumGateContext.tsx contexts/__tests__/PremiumGateContext.test.tsx features/tools/screens/CuratedManifestDetailScreen.tsx features/tools/screens/__tests__/CuratedManifestDetailScreen.test.tsx`
- `npx eslint --quiet features/auth/utils/userEntitlements.ts features/auth/utils/__tests__/userEntitlements.test.ts`
- `npx jest --runInBand contexts/__tests__/PremiumGateContext.test.tsx features/tools/screens/__tests__/CuratedManifestDetailScreen.test.tsx components/ui/modal/__tests__/PremiumGateModal.test.tsx features/auth/utils/__tests__/userEntitlements.test.ts`
