### PR TITLE
[codex] add session feedback flow

### DIFF
--- a/components/ui/modal/ProcessingModal.tsx
+++ b/components/ui/modal/ProcessingModal.tsx
@@ -1,10 +1,4 @@
-import React, {
-  ReactNode,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-} from "react";
+import React, { ReactNode, useContext, useEffect, useMemo, useRef } from "react";
 import {
   Animated,
   Easing,
@@ -14,6 +8,7 @@ import {
   Text,
   View,
 } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
 import { SafeAreaView } from "react-native-safe-area-context";
 import Svg, {
@@ -30,10 +25,14 @@ type ProcessingModalProps = {
   visible: boolean;
   centerMessage?: ReactNode;
   footerMessage?: ReactNode;
-  title?: string;
-  subtitle?: string;
+  title?: ReactNode;
+  titlePrefix?: string;
+  titleAccent?: string;
+  subtitle?: ReactNode;
   message?: ReactNode;
   onRequestClose?: () => void;
+  iconName?: keyof typeof Ionicons.glyphMap;
+  accentColor?: string;
 };
 
 const isTextLike = (value: ReactNode): value is string | number =>
@@ -57,7 +56,15 @@ const renderMessage = (
   return resolvedContent;
 };
 
-export default function ProcessingModal({
+export default function ProcessingModal(props: ProcessingModalProps) {
+  if (props.centerMessage !== undefined || props.footerMessage !== undefined) {
+    return <LegacyProcessingModal {...props} />;
+  }
+
+  return <FeedbackProcessingModal {...props} />;
+}
+
+function LegacyProcessingModal({
   visible,
   centerMessage,
   footerMessage,
@@ -74,7 +81,7 @@ export default function ProcessingModal({
 
   const styles = useMemo(
     () =>
-      makeStyles(
+      makeLegacyStyles(
         newTheme,
         spacing,
         bodyTextStyle,
@@ -444,7 +451,171 @@ export default function ProcessingModal({
   );
 }
 
-const makeStyles = (
+function FeedbackProcessingModal({
+  visible,
+  title,
+  titlePrefix,
+  titleAccent,
+  subtitle,
+  message,
+  iconName = "cloud-outline",
+  accentColor,
+}: ProcessingModalProps) {
+  const { svaColors, svaTypography, spacing } = useContext(ThemeContext);
+  const styles = useMemo(
+    () => makeFeedbackStyles(svaColors, svaTypography, spacing),
+    [spacing, svaColors, svaTypography]
+  );
+
+  const overlayOpacity = useRef(new Animated.Value(0)).current;
+  const pulseScale = useRef(new Animated.Value(1)).current;
+  const dot1 = useRef(new Animated.Value(0.35)).current;
+  const dot2 = useRef(new Animated.Value(0.9)).current;
+  const dot3 = useRef(new Animated.Value(0.35)).current;
+
+  const primaryAccent =
+    accentColor ?? svaColors?.brand?.primary ?? "#B8D39B";
+  const resolvedTitlePrefix = titlePrefix ?? "Crafting your";
+  const resolvedTitleAccent = titleAccent ?? "unique rhythm...";
+  const resolvedSubtitle =
+    subtitle ?? "Our AI is aligning your intentions with our soulful tools";
+  const resolvedMessage =
+    message && (typeof message !== "string" || message !== resolvedSubtitle)
+      ? message
+      : "";
+  const resolvedPlainTitle = title ?? resolvedTitlePrefix;
+  const hasSplitTitle = titlePrefix !== undefined || titleAccent !== undefined;
+
+  useEffect(() => {
+    if (!visible) {
+      overlayOpacity.setValue(0);
+      pulseScale.setValue(1);
+      dot1.setValue(0.35);
+      dot2.setValue(0.9);
+      dot3.setValue(0.35);
+      return;
+    }
+
+    Animated.timing(overlayOpacity, {
+      toValue: 1,
+      duration: 220,
+      useNativeDriver: true,
+    }).start();
+
+    const pulse = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulseScale, {
+          toValue: 1.04,
+          duration: 1200,
+          useNativeDriver: true,
+        }),
+        Animated.timing(pulseScale, {
+          toValue: 1,
+          duration: 1200,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+    pulse.start();
+
+    const dotLoop = (value: Animated.Value, delay: number) =>
+      Animated.loop(
+        Animated.sequence([
+          Animated.delay(delay),
+          Animated.timing(value, {
+            toValue: 1,
+            duration: 420,
+            useNativeDriver: true,
+          }),
+          Animated.timing(value, {
+            toValue: 0.35,
+            duration: 420,
+            useNativeDriver: true,
+          }),
+        ])
+      );
+
+    const dotLoop1 = dotLoop(dot1, 0);
+    const dotLoop2 = dotLoop(dot2, 160);
+    const dotLoop3 = dotLoop(dot3, 320);
+
+    dotLoop1.start();
+    dotLoop2.start();
+    dotLoop3.start();
+
+    return () => {
+      pulse.stop();
+      dotLoop1.stop();
+      dotLoop2.stop();
+      dotLoop3.stop();
+    };
+  }, [dot1, dot2, dot3, overlayOpacity, pulseScale, visible]);
+
+  if (!visible) return null;
+
+  return (
+    <Animated.View style={[styles.overlay, { opacity: overlayOpacity }]}>
+      <View style={styles.backdrop} />
+      <View style={styles.glowTop} />
+      <View style={styles.glowBottom} />
+
+      <View style={styles.center}>
+        <View style={styles.iconRing}>
+          <Animated.View
+            style={[
+              styles.pulseRing,
+              {
+                borderColor: primaryAccent,
+                transform: [{ scale: pulseScale }],
+              },
+            ]}
+          />
+          <View style={styles.iconTile}>
+            <Ionicons name={iconName} size={42} color={primaryAccent} />
+          </View>
+        </View>
+
+        {hasSplitTitle ? (
+          <Text style={styles.titleSplit}>
+            {resolvedTitlePrefix}
+            {"\n"}
+            <Text style={[styles.titleAccent, { color: primaryAccent }]}>
+              {resolvedTitleAccent}
+            </Text>
+          </Text>
+        ) : (
+          renderMessage(resolvedPlainTitle, styles.titlePlain)
+        )}
+
+        <Text style={styles.subtitle}>{resolvedSubtitle}</Text>
+        {!!resolvedMessage ? <Text style={styles.message}>{resolvedMessage}</Text> : null}
+      </View>
+
+      <View style={styles.dotsRow}>
+        <Animated.View
+          style={[
+            styles.dot,
+            { opacity: dot1, backgroundColor: primaryAccent },
+          ]}
+        />
+        <Animated.View
+          style={[
+            styles.dot,
+            { opacity: dot2, backgroundColor: primaryAccent },
+          ]}
+        />
+        <Animated.View
+          style={[
+            styles.dot,
+            { opacity: dot3, backgroundColor: primaryAccent },
+          ]}
+        />
+      </View>
+    </Animated.View>
+  );
+}
+
+const makeLegacyStyles = (
   t: any,
   spacing: any,
   bodyTextStyle: any,
@@ -580,5 +751,136 @@ const makeStyles = (
       textAlign: "center",
       fontWeight: "600",
       letterSpacing: 0.15,
+    },
+  });
+
+const makeFeedbackStyles = (t: any, svaTypography: any, spacing: any) =>
+  StyleSheet.create({
+    overlay: {
+      ...StyleSheet.absoluteFillObject,
+      zIndex: 999,
+    },
+    backdrop: {
+      ...StyleSheet.absoluteFillObject,
+      backgroundColor: "rgba(6, 8, 12, 0.94)",
+    },
+    glowTop: {
+      position: "absolute",
+      top: -40,
+      left: -30,
+      width: 220,
+      height: 220,
+      borderRadius: 110,
+      backgroundColor: "rgba(94,129,172,0.12)",
+    },
+    glowBottom: {
+      position: "absolute",
+      right: -40,
+      bottom: 28,
+      width: 240,
+      height: 240,
+      borderRadius: 120,
+      backgroundColor: "rgba(255,255,255,0.05)",
+    },
+    center: {
+      flex: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      paddingHorizontal: 32,
+    },
+    iconRing: {
+      width: 240,
+      height: 240,
+      alignItems: "center",
+      justifyContent: "center",
+      marginBottom: 24,
+    },
+    pulseRing: {
+      position: "absolute",
+      width: 230,
+      height: 230,
+      borderRadius: 115,
+      borderWidth: 1,
+      backgroundColor: "transparent",
+      opacity: 0.7,
+    },
+    iconTile: {
+      width: 136,
+      height: 136,
+      borderRadius: 36,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: "rgba(160, 169, 214, 0.18)",
+      borderWidth: 1,
+      borderColor: "rgba(255,255,255,0.08)",
+      ...Platform.select({
+        ios: {
+          shadowColor: "#000",
+          shadowOpacity: 0.18,
+          shadowOffset: { width: 0, height: 10 },
+          shadowRadius: 24,
+        },
+        android: { elevation: 4 },
+      }),
+    },
+    titleSplit: {
+      fontFamily:
+        svaTypography?.textStyle?.displayMedium?.fontFamily ??
+        "CormorantGaramond_500Medium",
+      fontSize: 34,
+      lineHeight: 36,
+      letterSpacing: -0.45,
+      textAlign: "center",
+      color: t.text.primary,
+    },
+    titleAccent: {
+      fontStyle: "italic",
+    },
+    titlePlain: {
+      fontFamily:
+        svaTypography?.textStyle?.displayMedium?.fontFamily ??
+        "CormorantGaramond_500Medium",
+      fontSize: 34,
+      lineHeight: 36,
+      letterSpacing: -0.45,
+      textAlign: "center",
+      color: t.text.primary,
+    },
+    subtitle: {
+      fontFamily:
+        svaTypography?.textStyle?.authSubtitle?.fontFamily ??
+        "Inter_400Regular",
+      fontSize: 14,
+      lineHeight: 22,
+      color: t.text.secondary,
+      textAlign: "center",
+      marginTop: 18,
+      maxWidth: 270,
+    },
+    message: {
+      fontFamily:
+        svaTypography?.textStyle?.authBody?.fontFamily ?? "Inter_400Regular",
+      fontSize: 12,
+      lineHeight: 18,
+      color: t.text.secondary,
+      textAlign: "center",
+      marginTop: 8,
+      maxWidth: 270,
+    },
+    dotsRow: {
+      position: "absolute",
+      left: 0,
+      right: 0,
+      bottom: spacing.xl,
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 6,
+    },
+    dot: {
+      width: 4,
+      height: 4,
+      borderRadius: 2,
+      backgroundColor: t.state.info,
     },
   });

--- a/config/apiConfig.ts
+++ b/config/apiConfig.ts
@@ -103,6 +103,14 @@ export const API_ENDPOINTS = {
 
   reportBug: `${BASE_URL}/api/v1/bug-reports/`,
   logFeedback: `${BASE_URL}/api/v1/feedback/`,
+  sessionFeedbackQuestions: (source?: string) =>
+    `${BASE_URL}/api/v1/feedback/session-questions/${
+      source ? `?source=${encodeURIComponent(source)}` : ""
+    }`,
+  sessionFeedbackAnswers: (source?: string) =>
+    `${BASE_URL}/api/v1/feedback/session-answers/${
+      source ? `?source=${encodeURIComponent(source)}` : ""
+    }`,
 
   personaQuestion: `${BASE_URL}/api/v1/profile/persona-questions/`,
   submitPersonaAnswers: `${BASE_URL}/api/v1/profile/persona-answers/`,

--- a/features/self-care/hooks/useAudioPlayback.ts
+++ b/features/self-care/hooks/useAudioPlayback.ts
@@ -7,6 +7,7 @@ type UseAudioPlaybackOptions = {
   source: Parameters<typeof Audio.Sound.createAsync>[0];
   autoPlay?: boolean;
   progressUpdateIntervalMillis?: number;
+  onDidFinish?: () => void;
 };
 
 const DEFAULT_AUDIO_MODE = {
@@ -20,12 +21,18 @@ export function useAudioPlayback({
   source,
   autoPlay = true,
   progressUpdateIntervalMillis = 500,
+  onDidFinish,
 }: UseAudioPlaybackOptions) {
   const soundRef = useRef<Audio.Sound | null>(null);
+  const didNotifyFinishRef = useRef(false);
   const [playbackStatus, setPlaybackStatus] = useState<AVPlaybackStatus | null>(
     null
   );
   const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    didNotifyFinishRef.current = false;
+  }, [source]);
 
   useEffect(() => {
     let active = true;
@@ -45,6 +52,14 @@ export function useAudioPlayback({
           (status) => {
             if (active) {
               setPlaybackStatus(status);
+              if (
+                status.isLoaded &&
+                status.didJustFinish &&
+                !didNotifyFinishRef.current
+              ) {
+                didNotifyFinishRef.current = true;
+                onDidFinish?.();
+              }
             }
           }
         );
@@ -72,7 +87,7 @@ export function useAudioPlayback({
       soundRef.current = null;
       void sound?.unloadAsync();
     };
-  }, [autoPlay, progressUpdateIntervalMillis, source]);
+  }, [autoPlay, onDidFinish, progressUpdateIntervalMillis, source]);
 
   const isPlaying = playbackStatus?.isLoaded ? playbackStatus.isPlaying : false;
   const positionMillis = playbackStatus?.isLoaded
@@ -106,13 +121,22 @@ export function useAudioPlayback({
     if (isPlaying) {
       await sound.pauseAsync();
     } else {
+      if (
+        playbackStatus?.isLoaded &&
+        (playbackStatus.didJustFinish ||
+          playbackStatus.positionMillis >=
+            Math.max((playbackStatus.durationMillis ?? 0) - 1000, 0))
+      ) {
+        didNotifyFinishRef.current = false;
+      }
       await sound.playAsync();
     }
-  }, [isPlaying]);
+  }, [isPlaying, playbackStatus]);
 
   const stop = useCallback(async () => {
     const sound = soundRef.current;
     if (!sound) return;
+    didNotifyFinishRef.current = false;
     await sound.stopAsync();
   }, []);
 
@@ -128,4 +152,3 @@ export function useAudioPlayback({
     stop,
   };
 }
-

--- a/features/self-care/screens/MeditationPlayerScreen.tsx
+++ b/features/self-care/screens/MeditationPlayerScreen.tsx
@@ -25,6 +25,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import ThemeContext from "@/contexts/ThemeContext";
 import { ScreenView } from "@/components/ui/theme-components/ScreenView";
+import SessionFeedbackModal from "@/features/session-feedback/components/SessionFeedbackModal";
 import { ROUTES } from "@/constants/routes";
 import MeditationPlayerHeader from "@/features/self-care/components/meditation/MeditationPlayerHeader";
 import MeditationTransportControls from "@/features/self-care/components/meditation/MeditationTransportControls";
@@ -115,12 +116,14 @@ export default function MeditationPlayerScreen() {
   const sessionCreatePromiseRef = useRef<Promise<string | null> | null>(null);
   const completionInFlightRef = useRef(false);
   const leavingScreenRef = useRef(false);
+  const feedbackPresentedRef = useRef(false);
   const [playbackStatus, setPlaybackStatus] = useState<AVPlaybackStatus | null>(
     null
   );
   const [isLoading, setIsLoading] = useState(true);
   const [isFavorite, setIsFavorite] = useState(false);
   const [ambientMode, setAmbientMode] = useState(false);
+  const [feedbackVisible, setFeedbackVisible] = useState(false);
   const [sessionStatus, setSessionStatus] = useState<
     "idle" | "creating" | "active" | "paused" | "completed"
   >("idle");
@@ -135,6 +138,11 @@ export default function MeditationPlayerScreen() {
       ? playbackStatus.durationMillis
       : 1;
   const progress = Math.min(positionMillis / durationMillis, 1);
+  const openFeedbackFlow = useCallback(() => {
+    if (feedbackPresentedRef.current) return;
+    feedbackPresentedRef.current = true;
+    setFeedbackVisible(true);
+  }, []);
 
   const playbackSource = useMemo(
     () => resolveMeditationPlaybackSource(meditationId, template.source ?? null),
@@ -160,6 +168,8 @@ export default function MeditationPlayerScreen() {
     leavingScreenRef.current = false;
     hasCompletedSessionRef.current = false;
     playbackPositionRef.current = 0;
+    feedbackPresentedRef.current = false;
+    setFeedbackVisible(false);
   }, [meditationId]);
 
   useEffect(() => {
@@ -307,9 +317,10 @@ export default function MeditationPlayerScreen() {
 
       if (status.didJustFinish) {
         void completeSession();
+        openFeedbackFlow();
       }
     },
-    [completeSession]
+    [completeSession, openFeedbackFlow]
   );
 
   useEffect(() => {
@@ -427,6 +438,17 @@ export default function MeditationPlayerScreen() {
 
   const handleOpenLibrary = useCallback(() => {
     router.push(ROUTES.AUTH.SELF_CARE_MEDITATION);
+  }, []);
+
+  const handleCloseFeedback = useCallback(() => {
+    feedbackPresentedRef.current = false;
+    setFeedbackVisible(false);
+  }, []);
+
+  const handleCompleteFeedback = useCallback(() => {
+    leavingScreenRef.current = true;
+    setFeedbackVisible(false);
+    router.back();
   }, []);
 
   return (
@@ -561,6 +583,14 @@ export default function MeditationPlayerScreen() {
             </View>
           ) : null}
         </ScrollView>
+
+        <SessionFeedbackModal
+          visible={feedbackVisible}
+          source="meditation"
+          sessionTitle={meditationTitle}
+          onClose={handleCloseFeedback}
+          onComplete={handleCompleteFeedback}
+        />
       </View>
     </ScreenView>
   );

--- a/features/self-care/screens/SoundscapePlayerScreen.tsx
+++ b/features/self-care/screens/SoundscapePlayerScreen.tsx
@@ -21,6 +21,7 @@ import { LinearGradient } from "expo-linear-gradient";
 
 import { ScreenView } from "@/components/ui/theme-components/ScreenView";
 import ThemeContext from "@/contexts/ThemeContext";
+import SessionFeedbackModal from "@/features/session-feedback/components/SessionFeedbackModal";
 import {
   buildSoundscapeResonanceLabel,
   buildSoundscapeSubtitle,
@@ -581,11 +582,19 @@ function SoundscapePlayerContent({
   const [sessionStatus, setSessionStatus] =
     useState<SoundscapeSessionStatus>("idle");
   const [sessionRef, setSessionRef] = useState<string | null>(null);
+  const [feedbackVisible, setFeedbackVisible] = useState(false);
   const sessionStatusRef = useRef<SoundscapeSessionStatus>("idle");
   const pauseSessionRef = useRef<(() => Promise<void>) | null>(null);
   const sessionCreatePromiseRef = useRef<Promise<string | null> | null>(null);
   const completionInFlightRef = useRef(false);
   const leavingScreenRef = useRef(false);
+  const feedbackPresentedRef = useRef(false);
+
+  const openFeedbackFlow = useCallback(() => {
+    if (feedbackPresentedRef.current) return;
+    feedbackPresentedRef.current = true;
+    setFeedbackVisible(true);
+  }, []);
 
   const {
     soundRef,
@@ -599,6 +608,7 @@ function SoundscapePlayerContent({
     source,
     autoPlay: false,
     progressUpdateIntervalMillis: 500,
+    onDidFinish: openFeedbackFlow,
   });
   const currentSound = soundRef.current;
 
@@ -609,6 +619,8 @@ function SoundscapePlayerContent({
     sessionCreatePromiseRef.current = null;
     completionInFlightRef.current = false;
     leavingScreenRef.current = false;
+    feedbackPresentedRef.current = false;
+    setFeedbackVisible(false);
   }, [soundscape.id]);
 
   useEffect(() => {
@@ -732,7 +744,7 @@ function SoundscapePlayerContent({
     }
   }, [resolveSessionRef, sessionStatus]);
 
-  const completeSession = useCallback(async () => {
+  const completeSession = useCallback(async (durationSecondsOverride?: number) => {
     if (completionInFlightRef.current || sessionStatus === "completed") {
       return;
     }
@@ -746,7 +758,8 @@ function SoundscapePlayerContent({
       }
 
       await completeWellnessSession(resolvedSessionRef, {
-        duration_seconds: Math.max(1, Math.round(durationMillis / 1000)),
+        duration_seconds:
+          durationSecondsOverride ?? Math.max(1, Math.round(durationMillis / 1000)),
       });
       setSessionStatus("completed");
     } catch (error) {
@@ -795,12 +808,13 @@ function SoundscapePlayerContent({
       if (currentSound) {
         void currentSound.stopAsync();
       }
-      void pauseSessionRef.current?.();
+      void completeSession(selectedMinutes * 60);
+      openFeedbackFlow();
       setTimerIndex(0);
     }, selectedMinutes * 60 * 1000);
 
     return () => clearTimeout(timeout);
-  }, [currentSound, timerIndex]);
+  }, [completeSession, currentSound, openFeedbackFlow, timerIndex]);
 
   const handlePlayPause = useCallback(async () => {
     if (isLoading || sessionStatus === "completed") {
@@ -847,6 +861,17 @@ function SoundscapePlayerContent({
 
     await onBack();
   }, [isPlaying, onBack, pauseSession, sessionStatus, togglePlayPause]);
+
+  const handleCloseFeedback = useCallback(() => {
+    feedbackPresentedRef.current = false;
+    setFeedbackVisible(false);
+  }, []);
+
+  const handleCompleteFeedback = useCallback(() => {
+    leavingScreenRef.current = true;
+    setFeedbackVisible(false);
+    router.back();
+  }, []);
 
   return (
     <ScreenView
@@ -1066,6 +1091,14 @@ function SoundscapePlayerContent({
             </View>
           </View>
         </ScrollView>
+
+        <SessionFeedbackModal
+          visible={feedbackVisible}
+          source="soundscape"
+          sessionTitle={soundscape.title}
+          onClose={handleCloseFeedback}
+          onComplete={handleCompleteFeedback}
+        />
       </View>
     </ScreenView>
   );

--- a/features/self-care/screens/__tests__/MeditationPlayerScreen.test.tsx
+++ b/features/self-care/screens/__tests__/MeditationPlayerScreen.test.tsx
@@ -112,6 +112,16 @@ jest.mock("../../services/wellnessSessionService", () => ({
     mockCompleteWellnessSessionFn(...args),
 }));
 
+jest.mock(
+  "../../../../features/session-feedback/components/SessionFeedbackModal",
+  () => {
+    const React = require("react");
+    return function MockSessionFeedbackModal() {
+      return null;
+    };
+  }
+);
+
 const theme = getTheme("sva");
 const themeValue = {
   theme: "sva",

--- a/features/session-feedback/components/SessionFeedbackModal.tsx
+++ b/features/session-feedback/components/SessionFeedbackModal.tsx
@@ -1,0 +1,684 @@
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  Animated,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import ThemeContext from "@/contexts/ThemeContext";
+import ProcessingModal from "@/components/ui/modal/ProcessingModal";
+
+import { FALLBACK_SESSION_FEEDBACK_QUESTIONS } from "../data/mockQuestions";
+import {
+  serializeSessionFeedbackAnswers,
+  submitSessionFeedbackAnswers,
+} from "../services/sessionFeedbackService";
+import type {
+  SessionFeedbackAnswersMap,
+  SessionFeedbackQuestion,
+} from "../types";
+import SessionFeedbackOptionCard from "./SessionFeedbackOptionCard";
+
+type SessionFeedbackModalProps = {
+  visible: boolean;
+  source: string;
+  onClose: () => void;
+  onComplete?: () => void;
+  sessionTitle?: string;
+};
+
+const TOTAL_STEPS = FALLBACK_SESSION_FEEDBACK_QUESTIONS.length;
+
+export default function SessionFeedbackModal({
+  visible,
+  source,
+  onClose,
+  onComplete,
+  sessionTitle,
+}: SessionFeedbackModalProps) {
+  const insets = useSafeAreaInsets();
+  const { svaColors, svaTypography, spacing } = useContext(ThemeContext);
+
+  const accentColor = svaColors.brand.primary;
+  const styles = useMemo(
+    () =>
+      makeStyles(
+        svaColors,
+        svaTypography,
+        spacing,
+        insets.top,
+        insets.bottom
+      ),
+    [insets.bottom, insets.top, spacing, svaColors, svaTypography]
+  );
+
+  const [questions, setQuestions] = useState<SessionFeedbackQuestion[]>(
+    FALLBACK_SESSION_FEEDBACK_QUESTIONS
+  );
+  const [currentStep, setCurrentStep] = useState(0);
+  const [answers, setAnswers] = useState<SessionFeedbackAnswersMap>({});
+  const [submitError, setSubmitError] = useState<string>("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const contentAnim = useRef(new Animated.Value(1)).current;
+  const hasRequestedCloseRef = useRef(false);
+
+  const resetFlow = useCallback(() => {
+    setQuestions(FALLBACK_SESSION_FEEDBACK_QUESTIONS);
+    setCurrentStep(0);
+    setAnswers({});
+    setSubmitError("");
+    setIsSubmitting(false);
+    hasRequestedCloseRef.current = false;
+    contentAnim.setValue(1);
+  }, [contentAnim]);
+
+  useEffect(() => {
+    if (!visible) {
+      resetFlow();
+      return;
+    }
+
+    setQuestions(FALLBACK_SESSION_FEEDBACK_QUESTIONS);
+    setCurrentStep(0);
+    setAnswers({});
+    setSubmitError("");
+    setIsSubmitting(false);
+    hasRequestedCloseRef.current = false;
+    contentAnim.setValue(1);
+  }, [contentAnim, resetFlow, visible]);
+
+  useEffect(() => {
+    if (!visible) return;
+
+    contentAnim.setValue(0);
+    Animated.timing(contentAnim, {
+      toValue: 1,
+      duration: 220,
+      useNativeDriver: true,
+    }).start();
+  }, [contentAnim, currentStep, visible]);
+
+  const currentQuestion = questions[currentStep];
+  const stepNumber = currentStep + 1;
+  const totalSteps = questions.length || TOTAL_STEPS;
+  const progress = Math.min(stepNumber / totalSteps, 1);
+  const progressLabel = `${Math.round(progress * 100)}%`;
+  const isLastStep = currentStep === totalSteps - 1;
+
+  const setSingleAnswer = useCallback((questionId: number, value: string) => {
+    setAnswers((prev) => ({ ...prev, [questionId]: value }));
+    setSubmitError("");
+  }, []);
+
+  const toggleMultiAnswer = useCallback((questionId: number, value: string) => {
+    setAnswers((prev) => {
+      const current = prev[questionId];
+      const list = Array.isArray(current) ? current : [];
+      const next = list.includes(value)
+        ? list.filter((entry) => entry !== value)
+        : [...list, value];
+
+      return { ...prev, [questionId]: next };
+    });
+
+    setSubmitError("");
+  }, []);
+
+  const isQuestionValid = useCallback(
+    (question: SessionFeedbackQuestion) => {
+      const value = answers[question.id];
+
+      if (question.selectionMode === "multiple") {
+        return Array.isArray(value) && value.length > 0;
+      }
+
+      return typeof value === "string" && value.trim().length > 0;
+    },
+    [answers]
+  );
+
+  const currentQuestionValid = currentQuestion
+    ? isQuestionValid(currentQuestion)
+    : false;
+  const currentQuestionAnswer = currentQuestion
+    ? answers[currentQuestion.id]
+    : undefined;
+
+  const goBack = useCallback(() => {
+    if (isSubmitting) return;
+
+    if (currentStep > 0) {
+      setSubmitError("");
+      setCurrentStep((value) => Math.max(0, value - 1));
+      return;
+    }
+
+    if (hasRequestedCloseRef.current) return;
+    hasRequestedCloseRef.current = true;
+    onClose();
+  }, [currentStep, isSubmitting, onClose]);
+
+  const submit = useCallback(async () => {
+    if (isSubmitting) return;
+
+    const payload = serializeSessionFeedbackAnswers(answers);
+    if (!Object.keys(payload).length) {
+      setSubmitError("Please answer at least one question before submitting.");
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      setSubmitError("");
+
+      const response = await submitSessionFeedbackAnswers(source, payload);
+      if (response && response.success === false) {
+        throw new Error(
+          response?.message ?? "Unable to submit your reflection right now."
+        );
+      }
+
+      setIsSubmitting(false);
+      onClose();
+      onComplete?.();
+    } catch (error: any) {
+      setIsSubmitting(false);
+      setSubmitError(
+        error?.message ??
+          error?.response?.data?.message ??
+          "Unable to submit your reflection right now."
+      );
+    }
+  }, [answers, isSubmitting, onClose, onComplete, source]);
+
+  const goNext = useCallback(() => {
+    if (!currentQuestion) return;
+
+    if (!isQuestionValid(currentQuestion)) {
+      setSubmitError("Please select at least one option to continue.");
+      return;
+    }
+
+    setSubmitError("");
+
+    if (currentStep < totalSteps - 1) {
+      setCurrentStep((value) => value + 1);
+      return;
+    }
+
+    void submit();
+  }, [currentQuestion, currentStep, isQuestionValid, submit, totalSteps]);
+
+  const handleOptionPress = useCallback(
+    (questionId: number, value: string) => {
+      if (!currentQuestion) return;
+
+      if (currentQuestion.selectionMode === "multiple") {
+        toggleMultiAnswer(questionId, value);
+        return;
+      }
+
+      setSingleAnswer(questionId, value);
+    },
+    [currentQuestion, setSingleAnswer, toggleMultiAnswer]
+  );
+
+  const renderHeadline = (question: SessionFeedbackQuestion) => (
+    <Text style={styles.questionTitle}>
+      {question.prefix}
+      {question.accent ? (
+        <>
+          {"\n"}
+          <Text style={styles.questionAccent}>{question.accent}</Text>
+        </>
+      ) : null}
+    </Text>
+  );
+
+  return (
+    <Modal
+      transparent
+      visible={visible}
+      animationType="fade"
+      statusBarTranslucent
+      onRequestClose={goBack}
+    >
+      <View style={styles.root}>
+        <View style={styles.backdrop} />
+        <View style={styles.glowTopLeft} />
+        <View style={styles.glowBottomRight} />
+
+        <View style={styles.contentShell}>
+          {currentQuestion ? (
+            <>
+              <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={styles.scrollContent}
+              >
+                <Animated.View
+                  style={[
+                    styles.inner,
+                    {
+                      opacity: contentAnim,
+                      transform: [
+                        {
+                          translateY: contentAnim.interpolate({
+                            inputRange: [0, 1],
+                            outputRange: [14, 0],
+                          }),
+                        },
+                      ],
+                    },
+                  ]}
+                >
+                  <View style={styles.topRow}>
+                    <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel={currentStep > 0 ? "Previous question" : "Close feedback"}
+                      onPress={goBack}
+                      style={({ pressed }) => [
+                        styles.backButton,
+                        pressed && styles.backButtonPressed,
+                      ]}
+                    >
+                      <Ionicons
+                        name="chevron-back"
+                        size={20}
+                        color={svaColors.text.primary}
+                      />
+                    </Pressable>
+
+                    <View style={styles.stepMeta}>
+                      <View style={styles.stepLabelRow}>
+                        <Text style={styles.stepLabel}>
+                          STEP {stepNumber} OF {totalSteps}
+                        </Text>
+                        <Text style={styles.percentLabel}>{progressLabel}</Text>
+                      </View>
+
+                      <View style={styles.progressTrack}>
+                        <View
+                          style={[
+                            styles.progressFill,
+                            { width: `${progress * 100}%` },
+                          ]}
+                        />
+                      </View>
+                    </View>
+                  </View>
+
+                  <View style={styles.titleBlock}>
+                    {renderHeadline(currentQuestion)}
+                    {!!currentQuestion.subtitle ? (
+                      <Text style={styles.subtitle}>
+                        {currentQuestion.subtitle}
+                      </Text>
+                    ) : null}
+                  </View>
+
+                  <View
+                    style={[
+                      styles.optionsBlock,
+                      currentQuestion.layout === "grid" && styles.gridOptionsBlock,
+                    ]}
+                  >
+                    {currentQuestion.options.map((option) => {
+                      const isSelected = Array.isArray(currentQuestionAnswer)
+                        ? currentQuestionAnswer.includes(option.id)
+                        : currentQuestionAnswer === option.id;
+
+                      return (
+                        <View
+                          key={option.id}
+                          style={
+                            currentQuestion.layout === "grid"
+                              ? styles.gridOptionWrap
+                              : styles.listOptionWrap
+                          }
+                        >
+                          <SessionFeedbackOptionCard
+                            option={option}
+                            selected={isSelected}
+                            layout={currentQuestion.layout}
+                            accentColor={accentColor}
+                            onPress={() =>
+                              handleOptionPress(currentQuestion.id, option.id)
+                            }
+                          />
+                        </View>
+                      );
+                    })}
+                  </View>
+
+                  {!!submitError ? (
+                    <View style={styles.errorPill}>
+                      <Ionicons
+                        name="alert-circle-outline"
+                        size={16}
+                        color={svaColors.state.error}
+                      />
+                      <Text style={styles.errorText}>{submitError}</Text>
+                    </View>
+                  ) : null}
+                </Animated.View>
+              </ScrollView>
+
+              <View style={styles.ctaShell} pointerEvents="box-none">
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={
+                    isLastStep ? "Complete discovery" : "Continue discovery"
+                  }
+                  disabled={!currentQuestionValid || isSubmitting}
+                  onPress={goNext}
+                  style={({ pressed }) => [
+                    styles.ctaButton,
+                    (!currentQuestionValid || isSubmitting) && styles.ctaDisabled,
+                    pressed && currentQuestionValid && !isSubmitting && styles.ctaPressed,
+                  ]}
+                >
+                  <Text style={styles.ctaText}>
+                    {isLastStep ? "Complete Discovery" : "Continue Discovery"}
+                  </Text>
+                  <Ionicons
+                    name="arrow-forward"
+                    size={18}
+                    color={svaColors.text.primary}
+                  />
+                </Pressable>
+              </View>
+            </>
+          ) : (
+            <View style={styles.emptyState}>
+              <View style={styles.emptyOrb}>
+                <Ionicons
+                  name="sparkles-outline"
+                  size={28}
+                  color={accentColor}
+                />
+              </View>
+              <Text style={styles.emptyTitle}>No questions available</Text>
+              <Text style={styles.emptySubtitle}>
+                We could not load a reflection set for this session right now.
+              </Text>
+            </View>
+          )}
+
+          <ProcessingModal
+            visible={isSubmitting}
+            titlePrefix="Crafting your"
+            titleAccent="unique rhythm..."
+            subtitle="Our AI is aligning your intentions with our soulful tools"
+            iconName="cloud-outline"
+            accentColor={accentColor}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const makeStyles = (
+  t: any,
+  svaTypography: any,
+  spacing: any,
+  topInset: number,
+  bottomInset: number
+) =>
+  StyleSheet.create({
+    root: {
+      flex: 1,
+      backgroundColor: t.bg.base,
+    },
+    backdrop: {
+      ...StyleSheet.absoluteFillObject,
+      backgroundColor: "rgba(6, 8, 12, 0.90)",
+    },
+    glowTopLeft: {
+      position: "absolute",
+      top: topInset - 24,
+      left: -100,
+      width: 260,
+      height: 260,
+      borderRadius: 130,
+      backgroundColor: "rgba(163,190,140,0.10)",
+    },
+    glowBottomRight: {
+      position: "absolute",
+      right: -120,
+      bottom: bottomInset - 44,
+      width: 320,
+      height: 320,
+      borderRadius: 160,
+      backgroundColor: "rgba(163,190,140,0.06)",
+    },
+    contentShell: {
+      flex: 1,
+      paddingHorizontal: 18,
+      paddingTop: topInset + 12,
+      paddingBottom: bottomInset + 16,
+      justifyContent: "space-between",
+    },
+    scrollContent: {
+      flexGrow: 1,
+      paddingBottom: 118,
+    },
+    inner: {
+      flex: 1,
+    },
+    topRow: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      gap: 12,
+    },
+    backButton: {
+      width: 36,
+      height: 36,
+      borderRadius: 12,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: "rgba(255,255,255,0.03)",
+      borderWidth: 1,
+      borderColor: "rgba(255,255,255,0.05)",
+    },
+    backButtonPressed: {
+      transform: [{ scale: 0.98 }],
+      opacity: 0.92,
+    },
+    stepMeta: {
+      flex: 1,
+      paddingTop: 2,
+    },
+    stepLabelRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      marginBottom: 8,
+    },
+    stepLabel: {
+      fontFamily:
+        svaTypography?.textStyle?.authTinyLabel?.fontFamily ?? "Inter_600SemiBold",
+      fontSize: 11,
+      lineHeight: 16,
+      letterSpacing: 2.8,
+      color: t.brand.primary,
+      textTransform: "uppercase",
+    },
+    percentLabel: {
+      fontFamily:
+        svaTypography?.textStyle?.authTinyLabel?.fontFamily ?? "Inter_600SemiBold",
+      fontSize: 11,
+      lineHeight: 16,
+      letterSpacing: 1.4,
+      color: t.text.secondary,
+    },
+    progressTrack: {
+      width: "100%",
+      height: 3,
+      borderRadius: 999,
+      backgroundColor: "rgba(255,255,255,0.08)",
+      overflow: "hidden",
+    },
+    progressFill: {
+      height: "100%",
+      borderRadius: 999,
+      backgroundColor: t.brand.primary,
+    },
+    titleBlock: {
+      marginTop: spacing.xl,
+      marginBottom: spacing.lg,
+    },
+    questionTitle: {
+      fontFamily:
+        svaTypography?.textStyle?.displayMedium?.fontFamily ??
+        "CormorantGaramond_500Medium",
+      fontSize: 36,
+      lineHeight: 38,
+      letterSpacing: -0.4,
+      color: t.text.primary,
+    },
+    questionAccent: {
+      color: t.brand.primary,
+      fontStyle: "italic",
+    },
+    subtitle: {
+      fontFamily:
+        svaTypography?.textStyle?.authSubtitle?.fontFamily ??
+        "Inter_400Regular",
+      fontSize: 14,
+      lineHeight: 22,
+      color: t.text.secondary,
+      marginTop: 12,
+      maxWidth: 310,
+    },
+    optionsBlock: {
+      gap: spacing.md,
+    },
+    listOptionWrap: {
+      width: "100%",
+    },
+    gridOptionsBlock: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      justifyContent: "space-between",
+      alignItems: "stretch",
+      gap: 0,
+    },
+    gridOptionWrap: {
+      width: "47%",
+      flexBasis: "47%",
+      maxWidth: "47%",
+      flexGrow: 0,
+      flexShrink: 0,
+      marginBottom: spacing.md,
+    },
+    errorPill: {
+      marginTop: spacing.lg,
+      borderRadius: 18,
+      backgroundColor: "rgba(191,97,106,0.10)",
+      borderWidth: 1,
+      borderColor: "rgba(191,97,106,0.18)",
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm,
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 8,
+    },
+    errorText: {
+      fontFamily:
+        svaTypography?.textStyle?.authBody?.fontFamily ?? "Inter_400Regular",
+      fontSize: 13,
+      lineHeight: 18,
+      color: t.state.error,
+      flex: 1,
+    },
+    ctaShell: {
+      position: "absolute",
+      left: 18,
+      right: 18,
+      bottom: bottomInset + 14,
+      borderRadius: 24,
+    },
+    ctaButton: {
+      minHeight: 58,
+      borderRadius: 20,
+      borderWidth: 1,
+      borderColor: "rgba(163,190,140,0.18)",
+      backgroundColor: "rgba(163,190,140,0.10)",
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 10,
+      paddingHorizontal: 22,
+      shadowColor: "#000",
+      shadowOpacity: 0.2,
+      shadowOffset: { width: 0, height: 10 },
+      shadowRadius: 20,
+      elevation: 3,
+    },
+    ctaDisabled: {
+      opacity: 0.42,
+    },
+    ctaPressed: {
+      transform: [{ scale: 0.99 }],
+    },
+    ctaText: {
+      fontFamily:
+        svaTypography?.textStyle?.button?.fontFamily ?? "Inter_600SemiBold",
+      fontSize: 16,
+      lineHeight: 20,
+      letterSpacing: 0.4,
+      color: t.text.primary,
+    },
+    emptyState: {
+      flex: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      paddingHorizontal: 24,
+    },
+    emptyOrb: {
+      width: 108,
+      height: 108,
+      borderRadius: 54,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: "rgba(163,190,140,0.08)",
+      borderWidth: 1,
+      borderColor: "rgba(163,190,140,0.16)",
+    },
+    emptyTitle: {
+      fontFamily:
+        svaTypography?.textStyle?.displayMedium?.fontFamily ??
+        "CormorantGaramond_500Medium",
+      fontSize: 28,
+      lineHeight: 32,
+      color: t.text.primary,
+      textAlign: "center",
+      marginTop: 20,
+    },
+    emptySubtitle: {
+      fontFamily:
+        svaTypography?.textStyle?.authSubtitle?.fontFamily ??
+        "Inter_400Regular",
+      fontSize: 14,
+      lineHeight: 20,
+      color: t.text.secondary,
+      textAlign: "center",
+      marginTop: 10,
+      maxWidth: 280,
+    },
+  });

--- a/features/session-feedback/components/SessionFeedbackOptionCard.tsx
+++ b/features/session-feedback/components/SessionFeedbackOptionCard.tsx
@@ -1,0 +1,263 @@
+import React, { useContext, useMemo } from "react";
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  Platform,
+  type ViewStyle,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+
+import ThemeContext from "@/contexts/ThemeContext";
+
+import type {
+  SessionFeedbackLayout,
+  SessionFeedbackOption,
+} from "../types";
+
+type SessionFeedbackOptionCardProps = {
+  option: SessionFeedbackOption;
+  selected: boolean;
+  layout: SessionFeedbackLayout;
+  accentColor: string;
+  onPress: () => void;
+};
+
+export default function SessionFeedbackOptionCard({
+  option,
+  selected,
+  layout,
+  accentColor,
+  onPress,
+}: SessionFeedbackOptionCardProps) {
+  const { svaColors, svaTypography, spacing } = useContext(ThemeContext);
+
+  const styles = useMemo(
+    () => makeStyles(svaColors, svaTypography, spacing),
+    [spacing, svaColors, svaTypography]
+  );
+
+  const containerStyle =
+    layout === "grid" ? styles.gridCard : styles.listCard;
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ selected }}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.cardBase,
+        containerStyle,
+        selected && styles.cardSelected,
+        pressed && styles.cardPressed,
+      ]}
+    >
+      {layout === "grid" ? (
+        <>
+          <View
+            style={[
+              styles.gridTopRow,
+              selected && styles.gridTopRowSelected,
+            ]}
+          >
+            <View
+              style={[
+                styles.iconTile,
+                selected && styles.iconTileSelected,
+              ]}
+            >
+              <Ionicons
+                name={option.icon}
+                size={21}
+                color={selected ? accentColor : svaColors.text.secondary}
+              />
+            </View>
+
+            <View
+              style={[
+                styles.selectionBadge,
+                selected && styles.selectionBadgeSelected,
+              ]}
+            >
+              {selected ? (
+                <Ionicons name="checkmark" size={14} color={accentColor} />
+              ) : null}
+            </View>
+          </View>
+
+          <View style={styles.gridTextBlock}>
+            <Text style={styles.title} numberOfLines={2}>
+              {option.label}
+            </Text>
+            {option.subtitle ? (
+              <Text style={styles.subtitle} numberOfLines={3}>
+                {option.subtitle}
+              </Text>
+            ) : null}
+          </View>
+        </>
+      ) : (
+        <View style={styles.listRow}>
+          <View
+            style={[
+              styles.iconTile,
+              selected && styles.iconTileSelected,
+            ]}
+          >
+            <Ionicons
+              name={option.icon}
+              size={21}
+              color={selected ? accentColor : svaColors.text.secondary}
+            />
+          </View>
+
+          <View style={styles.listTextBlock}>
+            <Text style={styles.title} numberOfLines={1}>
+              {option.label}
+            </Text>
+            {option.subtitle ? (
+              <Text style={styles.subtitle} numberOfLines={2}>
+                {option.subtitle}
+              </Text>
+            ) : null}
+          </View>
+
+          <View
+            style={[
+              styles.selectionRing,
+              selected && styles.selectionRingSelected,
+            ]}
+          >
+            {selected ? (
+              <Ionicons name="checkmark" size={14} color={accentColor} />
+            ) : null}
+          </View>
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+const makeStyles = (t: any, typography: any, spacing: any) =>
+  StyleSheet.create({
+    cardBase: {
+      backgroundColor: t.surface.base ?? t.surfaceMuted,
+      borderWidth: 1,
+      borderColor: t.border.muted ?? t.border.default,
+      overflow: "hidden",
+      ...Platform.select({
+        ios: {
+          shadowColor: "#000",
+          shadowOpacity: 0.12,
+          shadowOffset: { width: 0, height: 10 },
+          shadowRadius: 22,
+        },
+        android: { elevation: 2 },
+      }),
+    } as ViewStyle,
+    listCard: {
+      width: "100%",
+      minHeight: 80,
+      borderRadius: 24,
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.md,
+    } as ViewStyle,
+    gridCard: {
+      width: "100%",
+      minHeight: 180,
+      borderRadius: 24,
+      padding: spacing.md,
+    } as ViewStyle,
+    cardSelected: {
+      borderColor: "rgba(163,190,140,0.82)",
+      backgroundColor: "rgba(163,190,140,0.12)",
+      shadowColor: "rgba(163,190,140,0.26)",
+      shadowOpacity: 0.26,
+      shadowOffset: { width: 0, height: 10 },
+      shadowRadius: 20,
+      elevation: 6,
+    } as ViewStyle,
+    cardPressed: {
+      transform: [{ scale: 0.988 }],
+      opacity: 0.96,
+    } as ViewStyle,
+    listRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.md,
+    },
+    iconTile: {
+      width: 52,
+      height: 52,
+      borderRadius: 16,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: t.bg.subtle ?? "rgba(255,255,255,0.03)",
+      borderWidth: 1,
+      borderColor: t.border.subtle ?? t.border.muted,
+    },
+    iconTileSelected: {
+      backgroundColor: "rgba(163,190,140,0.18)",
+      borderColor: "rgba(163,190,140,0.28)",
+    } as ViewStyle,
+    listTextBlock: {
+      flex: 1,
+      gap: 4,
+    },
+    gridTopRow: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      justifyContent: "space-between",
+    },
+    gridTopRowSelected: {
+      marginBottom: 8,
+    },
+    gridTextBlock: {
+      flex: 1,
+      justifyContent: "flex-end",
+      gap: 6,
+      paddingTop: spacing.sm,
+    },
+    title: {
+      ...(typography?.textStyle?.title ?? {}),
+      fontSize: 18,
+      lineHeight: 22,
+      color: t.text.primary ?? t.textPrimary,
+      fontWeight: "600",
+    },
+    subtitle: {
+      ...(typography?.textStyle?.subtitle ?? {}),
+      fontSize: 13,
+      lineHeight: 18,
+      color: t.text.secondary ?? t.textSecondary,
+    },
+    selectionRing: {
+      width: 26,
+      height: 26,
+      borderRadius: 13,
+      borderWidth: 2,
+      borderColor: "rgba(255,255,255,0.14)",
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: "rgba(255,255,255,0.02)",
+    },
+    selectionRingSelected: {
+      backgroundColor: "rgba(163,190,140,0.18)",
+      borderColor: "rgba(163,190,140,0.80)",
+    },
+    selectionBadge: {
+      width: 24,
+      height: 24,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: "rgba(255,255,255,0.12)",
+      backgroundColor: "rgba(255,255,255,0.02)",
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    selectionBadgeSelected: {
+      backgroundColor: "rgba(163,190,140,0.18)",
+      borderColor: "rgba(163,190,140,0.80)",
+    },
+  });

--- a/features/session-feedback/data/mockQuestions.ts
+++ b/features/session-feedback/data/mockQuestions.ts
@@ -1,0 +1,184 @@
+import type { SessionFeedbackQuestion } from "../types";
+
+export const FALLBACK_SESSION_FEEDBACK_QUESTIONS: SessionFeedbackQuestion[] = [
+  {
+    id: 1,
+    order: 1,
+    prefix: "How do you greet",
+    accent: "the morning?",
+    subtitle:
+      "Select all the states that resonate with your recent waking experiences.",
+    selectionMode: "multiple",
+    layout: "list",
+    options: [
+      {
+        id: "restless-foggy",
+        label: "Restless & Foggy",
+        subtitle: "Feeling unrefreshed and heavy.",
+        icon: "cloud-outline",
+      },
+      {
+        id: "deeply-restored",
+        label: "Deeply Restored",
+        subtitle: "Waking up energized and clear.",
+        icon: "moon-outline",
+      },
+      {
+        id: "short-fragmented",
+        label: "Short & Fragmented",
+        subtitle: "Tossing and turning frequently.",
+        icon: "list-outline",
+      },
+      {
+        id: "natural-rhythms",
+        label: "Natural Rhythms",
+        subtitle: "Aligned with the sun and moon.",
+        icon: "water-outline",
+      },
+    ],
+  },
+  {
+    id: 2,
+    order: 2,
+    prefix: "What feels most",
+    accent: "present right now?",
+    subtitle:
+      "Choose the state that best describes your inner weather after the session.",
+    selectionMode: "single",
+    layout: "list",
+    options: [
+      {
+        id: "calm-open",
+        label: "Calm & Open",
+        subtitle: "The room feels wider and less crowded.",
+        icon: "sparkles-outline",
+      },
+      {
+        id: "soft-focused",
+        label: "Softly Focused",
+        subtitle: "Attention is steady without strain.",
+        icon: "compass-outline",
+      },
+      {
+        id: "still-foggy",
+        label: "Still Foggy",
+        subtitle: "The edges are quieter, but not yet clear.",
+        icon: "cloud-outline",
+      },
+      {
+        id: "more-awake",
+        label: "More Awake",
+        subtitle: "There is a lift, but it still needs settling.",
+        icon: "sunny-outline",
+      },
+    ],
+  },
+  {
+    id: 3,
+    order: 3,
+    prefix: "Where do you feel",
+    accent: "the shift most?",
+    subtitle:
+      "Pick the place where the session changes the most in your system.",
+    selectionMode: "single",
+    layout: "list",
+    options: [
+      {
+        id: "head-thoughts",
+        label: "Head & Thoughts",
+        subtitle: "The mind gets quieter.",
+        icon: "bulb-outline",
+      },
+      {
+        id: "chest-breath",
+        label: "Chest & Breath",
+        subtitle: "Breathing feels roomier.",
+        icon: "water-outline",
+      },
+      {
+        id: "shoulders-jaw",
+        label: "Shoulders & Jaw",
+        subtitle: "Tension begins to soften.",
+        icon: "scan-outline",
+      },
+      {
+        id: "whole-body",
+        label: "Whole Body",
+        subtitle: "Everything feels a little more even.",
+        icon: "leaf-outline",
+      },
+    ],
+  },
+  {
+    id: 4,
+    order: 4,
+    prefix: "How do you want",
+    accent: "the next hours to feel?",
+    subtitle:
+      "Choose the rhythm you want to carry forward after this session.",
+    selectionMode: "single",
+    layout: "list",
+    options: [
+      {
+        id: "steady-clear",
+        label: "Steady & Clear",
+        subtitle: "A clean lane through the day.",
+        icon: "compass-outline",
+      },
+      {
+        id: "soft-restful",
+        label: "Soft & Restful",
+        subtitle: "Lower the volume everywhere.",
+        icon: "moon-outline",
+      },
+      {
+        id: "focused-bright",
+        label: "Focused & Bright",
+        subtitle: "One thing at a time, with ease.",
+        icon: "scan-outline",
+      },
+      {
+        id: "light-energized",
+        label: "Light & Energized",
+        subtitle: "A little more lift and movement.",
+        icon: "sunny-outline",
+      },
+    ],
+  },
+  {
+    id: 5,
+    order: 5,
+    prefix: "What intention will we",
+    accent: "nurture?",
+    subtitle: "Select the seeds you wish to plant for your journey ahead.",
+    selectionMode: "multiple",
+    layout: "grid",
+    options: [
+      {
+        id: "clarity-of-mind",
+        label: "Clarity of Mind",
+        subtitle: "Thin the fog, find the light within.",
+        icon: "bulb-outline",
+      },
+      {
+        id: "physical-vitality",
+        label: "Physical Vitality",
+        subtitle: "Awaken the strength that sleeps.",
+        icon: "barbell-outline",
+      },
+      {
+        id: "soulful-rest",
+        label: "Soulful Rest",
+        subtitle: "Deep surrender to the quiet night.",
+        icon: "moon-outline",
+      },
+      {
+        id: "deep-focus",
+        label: "Deep Focus",
+        subtitle: "One point of light in the chaos.",
+        icon: "scan-outline",
+      },
+    ],
+  },
+];
+

--- a/features/session-feedback/services/sessionFeedbackService.ts
+++ b/features/session-feedback/services/sessionFeedbackService.ts
@@ -1,0 +1,238 @@
+import axios, { AxiosResponse } from "axios";
+import { API_ENDPOINTS } from "@/config/apiConfig";
+
+import { FALLBACK_SESSION_FEEDBACK_QUESTIONS } from "../data/mockQuestions";
+import type {
+  SessionFeedbackAnswersMap,
+  SessionFeedbackAnswersPayload,
+  SessionFeedbackLayout,
+  SessionFeedbackOption,
+  SessionFeedbackQuestion,
+  SessionFeedbackQuestionsResponse,
+  SubmitSessionFeedbackResponse,
+} from "../types";
+
+type RawFeedbackOption = {
+  id?: string | number;
+  label?: string;
+  title?: string;
+  subtitle?: string | null;
+  description?: string | null;
+  icon?: string | null;
+  icon_name?: string | null;
+  iconName?: string | null;
+};
+
+type RawFeedbackQuestion = {
+  id?: string | number;
+  order?: number | string | null;
+  step?: number | string | null;
+  title?: string | null;
+  prefix?: string | null;
+  accent?: string | null;
+  title_prefix?: string | null;
+  titlePrefix?: string | null;
+  title_accent?: string | null;
+  titleAccent?: string | null;
+  subtitle?: string | null;
+  description?: string | null;
+  selection_mode?: string | null;
+  selectionMode?: string | null;
+  layout?: string | null;
+  type?: string | null;
+  options?: RawFeedbackOption[] | null;
+};
+
+type RawFeedbackQuestionsResponse = {
+  success?: boolean;
+  message?: string;
+  data?: RawFeedbackQuestion[];
+  questions?: RawFeedbackQuestion[];
+};
+
+const toNumberOrNull = (value: unknown) => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+};
+
+const normalizeLayout = (value: unknown): SessionFeedbackLayout => {
+  return String(value).toLowerCase() === "grid" ? "grid" : "list";
+};
+
+const normalizeSelectionMode = (value: unknown) =>
+  String(value).toLowerCase() === "multiple" ? "multiple" : "single";
+
+const parseHeadline = (
+  raw: RawFeedbackQuestion,
+  fallback: SessionFeedbackQuestion
+) => {
+  const prefixSource =
+    raw.prefix ??
+    raw.title_prefix ??
+    raw.titlePrefix ??
+    fallback.prefix;
+  const accentSource =
+    raw.accent ??
+    raw.title_accent ??
+    raw.titleAccent ??
+    fallback.accent;
+
+  if (prefixSource || accentSource) {
+    return {
+      prefix: String(prefixSource ?? fallback.prefix),
+      accent: accentSource ? String(accentSource) : undefined,
+    };
+  }
+
+  const title = String(raw.title ?? "");
+  const [firstLine, ...rest] = title.split(/\n+/).map((part) => part.trim());
+
+  if (firstLine && rest.length > 0) {
+    return {
+      prefix: firstLine,
+      accent: rest.join(" "),
+    };
+  }
+
+  return {
+    prefix: title || fallback.prefix,
+    accent: fallback.accent,
+  };
+};
+
+const normalizeOption = (
+  raw: RawFeedbackOption | undefined,
+  fallback: SessionFeedbackOption,
+  index: number
+): SessionFeedbackOption => {
+  if (!raw) return fallback;
+
+  const iconCandidate = raw.icon ?? raw.icon_name ?? raw.iconName;
+
+  return {
+    id: String(raw.id ?? fallback.id ?? `option-${index + 1}`),
+    label: String(raw.label ?? raw.title ?? fallback.label),
+    subtitle: String(raw.subtitle ?? raw.description ?? fallback.subtitle ?? ""),
+    icon: (iconCandidate as SessionFeedbackOption["icon"]) ?? fallback.icon,
+  };
+};
+
+const normalizeQuestion = (
+  raw: RawFeedbackQuestion,
+  fallback: SessionFeedbackQuestion
+): SessionFeedbackQuestion => {
+  const headline = parseHeadline(raw, fallback);
+  const rawOptions = Array.isArray(raw.options) ? raw.options : [];
+
+  return {
+    id: fallback.id,
+    order: fallback.order,
+    prefix: headline.prefix,
+    accent: headline.accent,
+    subtitle: String(raw.subtitle ?? raw.description ?? fallback.subtitle ?? ""),
+    selectionMode: normalizeSelectionMode(
+      raw.selection_mode ?? raw.selectionMode ?? raw.type ?? fallback.selectionMode
+    ),
+    layout: normalizeLayout(raw.layout ?? fallback.layout),
+    options: fallback.options.map((option, index) =>
+      normalizeOption(rawOptions[index], option, index)
+    ),
+  };
+};
+
+const isQuestionArray = (value: unknown): value is RawFeedbackQuestion[] =>
+  Array.isArray(value);
+
+const extractQuestionArray = (
+  response: RawFeedbackQuestionsResponse
+): RawFeedbackQuestion[] => {
+  if (isQuestionArray(response.data)) return response.data;
+  if (isQuestionArray(response.questions)) return response.questions;
+  return [];
+};
+
+export function serializeSessionFeedbackAnswers(
+  answers: SessionFeedbackAnswersMap
+): SessionFeedbackAnswersPayload {
+  const payload: SessionFeedbackAnswersPayload = {};
+
+  Object.entries(answers).forEach(([questionId, value]) => {
+    if (value == null) return;
+    if (Array.isArray(value) && value.length === 0) return;
+    if (typeof value === "string" && !value.trim()) return;
+
+    payload[String(questionId)] = value;
+  });
+
+  return payload;
+}
+
+export async function fetchSessionFeedbackQuestions(
+  source: string
+): Promise<SessionFeedbackQuestionsResponse> {
+  const fallback = FALLBACK_SESSION_FEEDBACK_QUESTIONS.map((item) => ({
+    ...item,
+    options: item.options.map((option) => ({ ...option })),
+  }));
+
+  try {
+    const response: AxiosResponse<RawFeedbackQuestionsResponse> =
+      await axios.get(API_ENDPOINTS.sessionFeedbackQuestions(source));
+    const payload = response.data ?? {};
+    const rawQuestions = extractQuestionArray(payload);
+    const merged = [...fallback];
+
+    rawQuestions.slice(0, 5).forEach((rawQuestion, index) => {
+      const rawOrder = toNumberOrNull(rawQuestion.order ?? rawQuestion.step);
+      const rawId = toNumberOrNull(rawQuestion.id);
+      const slot =
+        rawOrder ??
+        (rawId !== null && rawId >= 1 && rawId <= 5 ? rawId : index + 1);
+      const fallbackQuestion =
+        merged[Math.max(0, Math.min(slot - 1, merged.length - 1))] ??
+        fallback[index] ??
+        fallback[0];
+
+      const normalized = normalizeQuestion(rawQuestion, fallbackQuestion);
+      const targetIndex = Math.max(0, Math.min(slot - 1, merged.length - 1));
+      merged[targetIndex] = {
+        ...fallbackQuestion,
+        ...normalized,
+        id: rawId ?? fallbackQuestion.id,
+        order: rawOrder ?? fallbackQuestion.order,
+      };
+    });
+
+    return {
+      success: payload.success ?? true,
+      message: payload.message ?? "Session feedback loaded.",
+      data: merged,
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      message:
+        error?.response?.data?.message ??
+        error?.message ??
+        "Unable to load session feedback questions.",
+      data: fallback,
+    };
+  }
+}
+
+export async function submitSessionFeedbackAnswers(
+  source: string,
+  payload: SessionFeedbackAnswersPayload
+): Promise<SubmitSessionFeedbackResponse> {
+  try {
+    const response: AxiosResponse<SubmitSessionFeedbackResponse> =
+      await axios.post(API_ENDPOINTS.sessionFeedbackAnswers(source), payload);
+    return response.data;
+  } catch (error: any) {
+    throw error?.response?.data ?? error;
+  }
+}

--- a/features/session-feedback/types.ts
+++ b/features/session-feedback/types.ts
@@ -1,0 +1,42 @@
+import { Ionicons } from "@expo/vector-icons";
+
+export type SessionFeedbackSelectionMode = "single" | "multiple";
+
+export type SessionFeedbackLayout = "list" | "grid";
+
+export type SessionFeedbackOption = {
+  id: string;
+  label: string;
+  subtitle?: string;
+  icon: keyof typeof Ionicons.glyphMap;
+};
+
+export type SessionFeedbackQuestion = {
+  id: number;
+  order: number;
+  prefix: string;
+  accent?: string;
+  subtitle?: string;
+  selectionMode: SessionFeedbackSelectionMode;
+  layout: SessionFeedbackLayout;
+  options: SessionFeedbackOption[];
+};
+
+export type SessionFeedbackAnswerValue = string | string[] | null | undefined;
+
+export type SessionFeedbackAnswersMap = Record<number, SessionFeedbackAnswerValue>;
+
+export type SessionFeedbackAnswersPayload = Record<string, string | string[]>;
+
+export type SessionFeedbackQuestionsResponse = {
+  success: boolean;
+  message: string;
+  data: SessionFeedbackQuestion[];
+};
+
+export type SubmitSessionFeedbackResponse = {
+  success: boolean;
+  message: string;
+  data?: unknown;
+};
+


### PR DESCRIPTION
## What changed
- Added a session feedback flow for meditation and soundscape sessions.
- Added modal UI, fallback questions, and submission plumbing.
- Hooked the modal into playback completion and timer expiry.

## Why
- Give users a structured reflection step after a session ends.

## Impact
- Users now see a post-session feedback flow from the self-care players.
- Feedback can be submitted to the session-feedback API endpoints when available.

## Validation
- `npx eslint` on the changed files: passed.
- `npm run lint`: fails on a pre-existing unrelated error in `components/ui/InlinedTimePicker.tsx` (`react-hooks/rules-of-hooks`).
- `git diff --check`: passed.
