### PR TITLE
[codex] integrate meditation wellness content

### DIFF
--- a/config/apiConfig.ts
+++ b/config/apiConfig.ts
@@ -59,6 +59,8 @@ export const API_ENDPOINTS = {
   getAudioBookList: `${BASE_URL}/api/v1/media/media-assets/?type=meditation&category=audioBook`,
   getMeditationList: `${BASE_URL}/api/v1/media/media-assets/?type=meditation&category=breathwork`,
   getWellnessContent: `${BASE_URL}/api/v1/wellness-content/`,
+  getWellnessContentDetail: (id: number | string) =>
+    `${BASE_URL}/api/v1/wellness-content/${id}/`,
 
   getMentalTestList: `${BASE_URL}/assesment/assessments/`,
 

--- a/config/apiConfig.ts
+++ b/config/apiConfig.ts
@@ -58,6 +58,7 @@ export const API_ENDPOINTS = {
   getShortVideoList: `${BASE_URL}/api/v1/media/media-assets/?type=shortVideo`,
   getAudioBookList: `${BASE_URL}/api/v1/media/media-assets/?type=meditation&category=audioBook`,
   getMeditationList: `${BASE_URL}/api/v1/media/media-assets/?type=meditation&category=breathwork`,
+  getWellnessContent: `${BASE_URL}/api/v1/wellness-content/`,
 
   getMentalTestList: `${BASE_URL}/assesment/assessments/`,
 

--- a/features/self-care/screens/MeditationDetailScreen.tsx
+++ b/features/self-care/screens/MeditationDetailScreen.tsx
@@ -18,15 +18,16 @@ import { ScreenView } from "@/components/ui/theme-components/ScreenView";
 import ThemeContext from "@/contexts/ThemeContext";
 import { ROUTES } from "@/constants/routes";
 import {
+  buildMeditationRouteParams,
   formatMeditationTagLabel,
+  hydrateMeditationTemplate,
   mockMeditationRecommendations,
+  type MeditationRouteParams,
   type MeditationTemplate,
 } from "@/features/self-care/utils/meditationLibrary";
 import type { ColorSet, Spacing, Typography, TypographyTokens } from "@/theme/types";
 
-type MeditationDetailParams = {
-  meditationId?: string | string[];
-};
+type MeditationDetailParams = MeditationRouteParams;
 
 const HERO_IMAGE = require("../../../assets/images/mt.jpg");
 
@@ -85,12 +86,15 @@ export default function MeditationDetailScreen() {
   const [isFavorite, setIsFavorite] = useState(false);
 
   const meditationId = parseParam(params.meditationId) ?? "";
-  const meditation = useMemo<MeditationTemplate>(() => {
+  const fallbackMeditation = useMemo<MeditationTemplate>(() => {
     return (
-      mockMeditationRecommendations.find((item) => item.id === meditationId) ??
-      mockMeditationRecommendations[0]
+      mockMeditationRecommendations.find(
+        (item) => item.id === meditationId || item.slug === meditationId
+      ) ?? mockMeditationRecommendations[0]
     );
   }, [meditationId]);
+
+  const meditation = hydrateMeditationTemplate(params, fallbackMeditation);
 
   const styles = useMemo(
     () => styling(theme, svaTypography, spacing, typography),
@@ -112,12 +116,7 @@ export default function MeditationDetailScreen() {
   const handleStartMeditation = () => {
     router.push({
       pathname: ROUTES.AUTH.SELF_CARE_MEDITATION_PLAYER,
-      params: {
-        meditationId: meditation.id,
-        meditationTitle: meditation.title,
-        meditationDescription: meditation.description,
-        meditationDurationLabel: meditation.durationLabel,
-      },
+      params: buildMeditationRouteParams(meditation),
     });
   };
 

--- a/features/self-care/screens/MeditationDetailScreen.tsx
+++ b/features/self-care/screens/MeditationDetailScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, useMemo, useState } from "react";
 import {
+  ActivityIndicator,
   Platform,
   ScrollView,
   Share,
@@ -17,10 +18,12 @@ import { NimbusButton } from "@/components/ui/theme-components/NimbusButton";
 import { ScreenView } from "@/components/ui/theme-components/ScreenView";
 import ThemeContext from "@/contexts/ThemeContext";
 import { ROUTES } from "@/constants/routes";
+import { getWellnessContentDetail } from "@/features/self-care/services/selfCareService";
 import {
   buildMeditationRouteParams,
   formatMeditationTagLabel,
   hydrateMeditationTemplate,
+  mapMeditationTemplate,
   mockMeditationRecommendations,
   type MeditationRouteParams,
   type MeditationTemplate,
@@ -29,6 +32,12 @@ import type { ColorSet, Spacing, Typography, TypographyTokens } from "@/theme/ty
 
 type MeditationDetailParams = MeditationRouteParams;
 
+type BenefitItem = {
+  id: number | string;
+  title: string;
+  text: string;
+};
+
 const HERO_IMAGE = require("../../../assets/images/mt.jpg");
 
 const parseParam = (value?: string | string[]) => {
@@ -36,44 +45,118 @@ const parseParam = (value?: string | string[]) => {
   return value;
 };
 
-const buildBenefits = (template: MeditationTemplate) => {
+const isNumericId = (value: string) => /^\d+$/.test(value.trim());
+
+const buildFallbackBenefits = (template: MeditationTemplate): BenefitItem[] => {
   switch (template.tag) {
     case "sleep":
       return [
-        "Slow the system before the evening gives way to rest.",
-        "Unwind the body with a gentler pace and softer attention.",
-        "Carry a quieter rhythm into the next stretch of the day.",
+        {
+          id: "sleep-1",
+          title: "Restorative winding down",
+          text: "Slows the system before the evening gives way to rest.",
+        },
+        {
+          id: "sleep-2",
+          title: "Gentler breath rhythm",
+          text: "Encourages a softer pace that feels easier to release into sleep.",
+        },
+        {
+          id: "sleep-3",
+          title: "Quiet transition",
+          text: "Carries a calmer cadence into the next stretch of the day.",
+        },
       ];
     case "focus":
       return [
-        "Return the mind to one clear point at a time.",
-        "Set a steadier cadence before deep work or study.",
-        "Reduce noise so attention can settle without force.",
+        {
+          id: "focus-1",
+          title: "Attentional clarity",
+          text: "Returns the mind to one point at a time without force.",
+        },
+        {
+          id: "focus-2",
+          title: "Deeper work prep",
+          text: "Sets a steadier cadence before study or deep work.",
+        },
+        {
+          id: "focus-3",
+          title: "Less mental noise",
+          text: "Creates space for attention to settle without friction.",
+        },
       ];
     case "breath":
       return [
-        "Use the breath as a precise anchor for the session.",
-        "Lengthen each cycle to create a slower internal tempo.",
-        "Ease the body into a more grounded presence.",
+        {
+          id: "breath-1",
+          title: "Breath as anchor",
+          text: "Uses the inhale and exhale as a precise focus point.",
+        },
+        {
+          id: "breath-2",
+          title: "Slower internal tempo",
+          text: "Lengthens each cycle to create a calmer rhythm.",
+        },
+        {
+          id: "breath-3",
+          title: "Grounded presence",
+          text: "Eases the body into a more supported state.",
+        },
       ];
     case "release":
       return [
-        "Let tension soften without needing to be solved.",
-        "Open a little space around the shoulders and jaw.",
-        "Move the day out of the body with care.",
+        {
+          id: "release-1",
+          title: "Tension softening",
+          text: "Lets the shoulders and jaw relax without needing to solve anything.",
+        },
+        {
+          id: "release-2",
+          title: "Gentler exhale",
+          text: "Uses the breath to move the day out of the body with care.",
+        },
+        {
+          id: "release-3",
+          title: "Room to unwind",
+          text: "Opens a little more space around the edges of effort.",
+        },
       ];
     case "beginner":
       return [
-        "Start with a low-friction entry into meditation.",
-        "Follow a simple rhythm that stays easy to return to.",
-        "Build confidence without asking for too much too soon.",
+        {
+          id: "beginner-1",
+          title: "Low-friction entry",
+          text: "Starts with a simple rhythm that stays easy to return to.",
+        },
+        {
+          id: "beginner-2",
+          title: "Confidence builder",
+          text: "Helps new meditators settle without asking too much too soon.",
+        },
+        {
+          id: "beginner-3",
+          title: "Steady repetition",
+          text: "Reinforces the basics so the practice feels approachable.",
+        },
       ];
     case "calm":
     default:
       return [
-        "Quiet the nervous system before the next transition.",
-        "Create a steady pause that feels premium and unhurried.",
-        "Carry a softer internal tone into the rest of the day.",
+        {
+          id: "calm-1",
+          title: "Nervous system reset",
+          text: "Supports a quieter pause before the next transition.",
+        },
+        {
+          id: "calm-2",
+          title: "Soft, premium pacing",
+          text: "Creates a deliberate stillness that feels unhurried.",
+        },
+        {
+          id: "calm-3",
+          title: "Softer internal tone",
+          text: "Helps the rest of the day feel less sharp around the edges.",
+        },
       ];
   }
 };
@@ -84,6 +167,8 @@ export default function MeditationDetailScreen() {
   const { newTheme: theme, svaTypography, spacing, typography } =
     useContext(ThemeContext);
   const [isFavorite, setIsFavorite] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const meditationId = parseParam(params.meditationId) ?? "";
   const fallbackMeditation = useMemo<MeditationTemplate>(() => {
@@ -94,18 +179,75 @@ export default function MeditationDetailScreen() {
     );
   }, [meditationId]);
 
-  const meditation = hydrateMeditationTemplate(params, fallbackMeditation);
+  const initialMeditation = useMemo(
+    () => hydrateMeditationTemplate(params, fallbackMeditation),
+    [fallbackMeditation, params]
+  );
+
+  const [meditation, setMeditation] = useState<MeditationTemplate>(
+    initialMeditation
+  );
 
   const styles = useMemo(
     () => styling(theme, svaTypography, spacing, typography),
     [theme, svaTypography, spacing, typography]
   );
 
-  const benefits = useMemo(() => buildBenefits(meditation), [meditation]);
-
   useEffect(() => {
     navigation.setOptions({ headerShown: false });
   }, [navigation]);
+
+  useEffect(() => {
+    let active = true;
+
+    setMeditation(initialMeditation);
+    setLoadError(null);
+
+    if (!isNumericId(meditationId)) {
+      setIsLoading(false);
+      return () => {
+        active = false;
+      };
+    }
+
+    setIsLoading(true);
+
+    void getWellnessContentDetail(Number(meditationId))
+      .then((response) => {
+        if (!active) return;
+        setMeditation(mapMeditationTemplate(response.data, 0));
+      })
+      .catch((error) => {
+        console.warn("Unable to load meditation details:", error);
+        if (active) {
+          setLoadError("Unable to load the latest meditation details.");
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [initialMeditation, meditationId]);
+
+  const benefits = useMemo<BenefitItem[]>(
+    () =>
+      meditation.benefits?.length
+        ? meditation.benefits.map((benefit) => ({
+            id: benefit.id,
+            title: benefit.title,
+            text: benefit.text,
+          }))
+        : buildFallbackBenefits(meditation),
+    [meditation]
+  );
+
+  const ratingLabel =
+    typeof meditation.rating === "number" ? meditation.rating.toFixed(1) : "4.9";
 
   const handleShare = async () => {
     await Share.share({
@@ -152,7 +294,11 @@ export default function MeditationDetailScreen() {
           ]}
         >
           <View style={styles.heroCard}>
-            <Image source={meditation.image ?? HERO_IMAGE} style={styles.heroImage} contentFit="cover" />
+            <Image
+              source={meditation.image ?? HERO_IMAGE}
+              style={styles.heroImage}
+              contentFit="cover"
+            />
             <LinearGradient
               colors={["rgba(9, 11, 8, 0.02)", "rgba(9, 11, 8, 0.84)"]}
               style={StyleSheet.absoluteFill}
@@ -167,29 +313,132 @@ export default function MeditationDetailScreen() {
                 {meditation.title}
               </Text>
               <Text style={styles.heroSubtext}>
-                {meditation.durationLabel} · {formatMeditationTagLabel(meditation.tag)}
+                {meditation.durationLabel}
+                {meditation.category ? ` · ${meditation.category}` : ""}
               </Text>
+
+              <View style={styles.heroMetaRow}>
+                <View style={styles.heroMetaPill}>
+                  <Ionicons
+                    name="star"
+                    size={12}
+                    color={theme.chart2 ?? theme.accent}
+                  />
+                  <Text style={styles.heroMetaText}>{ratingLabel}</Text>
+                </View>
+                <View style={styles.heroMetaPill}>
+                  <Ionicons
+                    name="leaf-outline"
+                    size={12}
+                    color={theme.chart2 ?? theme.accent}
+                  />
+                  <Text style={styles.heroMetaText}>
+                    {meditation.dosha ?? "All doshas"}
+                  </Text>
+                </View>
+                <View style={styles.heroMetaPill}>
+                  <Ionicons
+                    name="layers-outline"
+                    size={12}
+                    color={theme.chart2 ?? theme.accent}
+                  />
+                  <Text style={styles.heroMetaText}>
+                    {meditation.level ?? "All levels"}
+                  </Text>
+                </View>
+              </View>
+
+              {isLoading ? (
+                <View style={styles.loadingChip}>
+                  <ActivityIndicator
+                    size="small"
+                    color={theme.chart2 ?? theme.accent}
+                  />
+                  <Text style={styles.loadingChipText}>Refreshing details</Text>
+                </View>
+              ) : null}
             </View>
           </View>
 
           <View style={styles.descriptionCard}>
             <View style={styles.cardHeaderRow}>
               <Text style={styles.cardLabel}>ABOUT THIS SESSION</Text>
-              <Text style={styles.cardMeta}>{meditation.durationLabel}</Text>
+              <Text style={styles.cardMeta}>
+                {meditation.date ?? meditation.durationLabel}
+              </Text>
             </View>
 
             <Text style={styles.descriptionText}>{meditation.description}</Text>
 
-            <View style={styles.tagsRow}>
-              {meditation.tags.slice(0, 3).map((tag) => (
-                <View key={tag} style={styles.tagChip}>
-                  <Text style={styles.tagText}>
-                    #{formatMeditationTagLabel(tag).toUpperCase()}
+            {meditation.longDescription ? (
+              <Text style={styles.longDescriptionText}>
+                {meditation.longDescription}
+              </Text>
+            ) : null}
+
+            {meditation.tags.length > 0 ? (
+              <View style={styles.tagsRow}>
+                {meditation.tags.slice(0, 4).map((tag) => (
+                  <View key={tag} style={styles.tagChip}>
+                    <Text style={styles.tagText}>
+                      #{formatMeditationTagLabel(tag).toUpperCase()}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            ) : null}
+          </View>
+
+          {meditation.guidance ? (
+            <View style={styles.guidanceCard}>
+              <View style={styles.cardHeaderRow}>
+                <Text style={styles.cardLabel}>GUIDANCE</Text>
+                <View style={styles.miniPill}>
+                  <Ionicons
+                    name="sparkles-outline"
+                    size={14}
+                    color={theme.textSecondary}
+                  />
+                  <Text style={styles.miniPillText}>Practice cues</Text>
+                </View>
+              </View>
+
+              <Text style={styles.sectionBodyText}>{meditation.guidance}</Text>
+            </View>
+          ) : null}
+
+          {meditation.instructor ? (
+            <View style={styles.instructorCard}>
+              <View style={styles.cardHeaderRow}>
+                <Text style={styles.cardLabel}>INSTRUCTOR</Text>
+                <Text style={styles.cardMeta}>{meditation.category}</Text>
+              </View>
+
+              <View style={styles.instructorRow}>
+                <Image
+                  source={
+                    meditation.instructor.image
+                      ? { uri: meditation.instructor.image }
+                      : HERO_IMAGE
+                  }
+                  style={styles.instructorAvatar}
+                  contentFit="cover"
+                />
+
+                <View style={styles.instructorCopy}>
+                  <Text style={styles.instructorName}>
+                    {meditation.instructor.name}
+                  </Text>
+                  <Text style={styles.instructorRole}>
+                    {meditation.instructor.role}
+                  </Text>
+                  <Text style={styles.instructorBio}>
+                    {meditation.instructor.bio}
                   </Text>
                 </View>
-              ))}
+              </View>
             </View>
-          </View>
+          ) : null}
 
           <View style={styles.benefitCard}>
             <View style={styles.cardHeaderRow}>
@@ -201,14 +450,14 @@ export default function MeditationDetailScreen() {
                   color={theme.textSecondary}
                 />
                 <Text style={styles.miniPillText}>
-                  {formatMeditationTagLabel(meditation.tag).toUpperCase()}
+                  {benefits.length} insights
                 </Text>
               </View>
             </View>
 
             <View style={styles.benefitList}>
               {benefits.map((benefit) => (
-                <View key={benefit} style={styles.benefitRow}>
+                <View key={benefit.id} style={styles.benefitRow}>
                   <View style={styles.benefitIcon}>
                     <Ionicons
                       name="checkmark"
@@ -216,11 +465,48 @@ export default function MeditationDetailScreen() {
                       color={theme.background}
                     />
                   </View>
-                  <Text style={styles.benefitText}>{benefit}</Text>
+
+                  <View style={styles.benefitCopy}>
+                    <Text style={styles.benefitTitle}>{benefit.title}</Text>
+                    <Text style={styles.benefitText}>{benefit.text}</Text>
+                  </View>
                 </View>
               ))}
             </View>
           </View>
+
+          {meditation.scientificSynthesis ? (
+            <View style={styles.scienceCard}>
+              <View style={styles.cardHeaderRow}>
+                <Text style={styles.cardLabel}>SCIENTIFIC SYNTHESIS</Text>
+                <Text style={styles.cardMeta}>Evidence-informed</Text>
+              </View>
+
+              <Text style={styles.scienceTitle}>
+                {meditation.scientificSynthesis.title}
+              </Text>
+              <Text style={styles.sectionBodyText}>
+                {meditation.scientificSynthesis.text}
+              </Text>
+              <Text style={styles.scienceSource}>
+                Source: {meditation.scientificSynthesis.source}
+              </Text>
+            </View>
+          ) : null}
+
+          {loadError ? (
+            <View style={styles.errorCard}>
+              <View style={styles.cardHeaderRow}>
+                <Text style={styles.errorTitle}>Detail unavailable</Text>
+                <Ionicons
+                  name="warning-outline"
+                  size={16}
+                  color="#F7C48B"
+                />
+              </View>
+              <Text style={styles.errorText}>{loadError}</Text>
+            </View>
+          ) : null}
 
           <NimbusButton
             label="Start Meditation"
@@ -264,7 +550,7 @@ const styling = (
       paddingBottom: spacing.xl,
     },
     heroCard: {
-      height: 320,
+      height: 332,
       borderRadius: 30,
       overflow: "hidden",
       backgroundColor: theme.surface,
@@ -330,7 +616,89 @@ const styling = (
       marginTop: 10,
       letterSpacing: 0.3,
     },
+    heroMetaRow: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      gap: 8,
+      marginTop: 14,
+    },
+    heroMetaPill: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      paddingHorizontal: 10,
+      paddingVertical: 6,
+      borderRadius: 999,
+      backgroundColor: "rgba(7, 9, 7, 0.48)",
+      borderWidth: 1,
+      borderColor: "rgba(255,255,255,0.08)",
+    },
+    heroMetaText: {
+      ...typography.smallCaption,
+      color: theme.textPrimary,
+      letterSpacing: 0.8,
+    },
+    loadingChip: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 8,
+      paddingHorizontal: 10,
+      paddingVertical: 8,
+      borderRadius: 999,
+      marginTop: 12,
+      alignSelf: "flex-start",
+      backgroundColor: "rgba(7, 9, 7, 0.52)",
+      borderWidth: 1,
+      borderColor: "rgba(255,255,255,0.08)",
+    },
+    loadingChipText: {
+      ...typography.smallCaption,
+      color: theme.textPrimary,
+      letterSpacing: 0.8,
+    },
+    sectionCardBase: {
+      borderRadius: 28,
+      backgroundColor: theme.surface,
+      borderWidth: 1,
+      borderColor: theme.borderMuted ?? "rgba(255,255,255,0.05)",
+      paddingHorizontal: 18,
+      paddingVertical: 18,
+      marginBottom: spacing.lg,
+      shadowColor: theme.shadow,
+      shadowOpacity: 0.18,
+      shadowRadius: 16,
+      shadowOffset: { width: 0, height: 10 },
+      elevation: 5,
+    },
     descriptionCard: {
+      borderRadius: 28,
+      backgroundColor: theme.surface,
+      borderWidth: 1,
+      borderColor: theme.borderMuted ?? "rgba(255,255,255,0.05)",
+      paddingHorizontal: 18,
+      paddingVertical: 18,
+      marginBottom: spacing.lg,
+      shadowColor: theme.shadow,
+      shadowOpacity: 0.18,
+      shadowRadius: 16,
+      shadowOffset: { width: 0, height: 10 },
+      elevation: 5,
+    },
+    guidanceCard: {
+      borderRadius: 28,
+      backgroundColor: theme.surface,
+      borderWidth: 1,
+      borderColor: theme.borderMuted ?? "rgba(255,255,255,0.05)",
+      paddingHorizontal: 18,
+      paddingVertical: 18,
+      marginBottom: spacing.lg,
+      shadowColor: theme.shadow,
+      shadowOpacity: 0.18,
+      shadowRadius: 16,
+      shadowOffset: { width: 0, height: 10 },
+      elevation: 5,
+    },
+    instructorCard: {
       borderRadius: 28,
       backgroundColor: theme.surface,
       borderWidth: 1,
@@ -351,12 +719,35 @@ const styling = (
       borderColor: theme.borderMuted ?? "rgba(255,255,255,0.05)",
       paddingHorizontal: 18,
       paddingVertical: 18,
-      marginBottom: spacing.xl,
+      marginBottom: spacing.lg,
       shadowColor: theme.shadow,
       shadowOpacity: 0.18,
       shadowRadius: 16,
       shadowOffset: { width: 0, height: 10 },
       elevation: 5,
+    },
+    scienceCard: {
+      borderRadius: 28,
+      backgroundColor: theme.surface,
+      borderWidth: 1,
+      borderColor: theme.borderMuted ?? "rgba(255,255,255,0.05)",
+      paddingHorizontal: 18,
+      paddingVertical: 18,
+      marginBottom: spacing.lg,
+      shadowColor: theme.shadow,
+      shadowOpacity: 0.18,
+      shadowRadius: 16,
+      shadowOffset: { width: 0, height: 10 },
+      elevation: 5,
+    },
+    errorCard: {
+      borderRadius: 28,
+      backgroundColor: "rgba(247, 196, 139, 0.08)",
+      borderWidth: 1,
+      borderColor: "rgba(247, 196, 139, 0.18)",
+      paddingHorizontal: 18,
+      paddingVertical: 18,
+      marginBottom: spacing.lg,
     },
     cardHeaderRow: {
       flexDirection: "row",
@@ -386,6 +777,14 @@ const styling = (
       lineHeight: 26,
       color: theme.textPrimary,
       opacity: 0.96,
+    },
+    longDescriptionText: {
+      fontFamily:
+        svaTypography?.textStyle.body.fontFamily ?? "Inter_400Regular",
+      fontSize: 15,
+      lineHeight: 24,
+      color: theme.textSecondary,
+      marginTop: 14,
     },
     tagsRow: {
       flexDirection: "row",
@@ -422,6 +821,50 @@ const styling = (
       color: theme.textSecondary,
       letterSpacing: 1,
     },
+    sectionBodyText: {
+      fontFamily:
+        svaTypography?.textStyle.body.fontFamily ?? "Inter_400Regular",
+      fontSize: 15,
+      lineHeight: 24,
+      color: theme.textPrimary,
+    },
+    instructorRow: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      gap: 14,
+    },
+    instructorAvatar: {
+      width: 64,
+      height: 64,
+      borderRadius: 20,
+      backgroundColor: theme.surfaceMuted,
+    },
+    instructorCopy: {
+      flex: 1,
+      minWidth: 0,
+    },
+    instructorName: {
+      ...typography.h3,
+      color: theme.textPrimary,
+      marginBottom: 4,
+    },
+    instructorRole: {
+      fontFamily:
+        svaTypography?.textStyle.authTinyLabel.fontFamily ?? "Inter_600SemiBold",
+      fontSize: 11,
+      lineHeight: 14,
+      letterSpacing: 1.2,
+      color: theme.chart2 ?? theme.accent,
+      textTransform: "uppercase",
+    },
+    instructorBio: {
+      fontFamily:
+        svaTypography?.textStyle.body.fontFamily ?? "Inter_400Regular",
+      fontSize: 15,
+      lineHeight: 24,
+      color: theme.textSecondary,
+      marginTop: 8,
+    },
     benefitList: {
       gap: 12,
     },
@@ -439,11 +882,42 @@ const styling = (
       backgroundColor: theme.accent,
       marginTop: 2,
     },
-    benefitText: {
+    benefitCopy: {
       flex: 1,
+      minWidth: 0,
+    },
+    benefitTitle: {
       ...typography.body,
       color: theme.textPrimary,
+      fontWeight: "600",
+      marginBottom: 4,
+    },
+    benefitText: {
+      ...typography.body,
+      color: theme.textSecondary,
       lineHeight: 24,
+    },
+    scienceTitle: {
+      ...typography.h3,
+      color: theme.textPrimary,
+      marginBottom: 10,
+    },
+    scienceSource: {
+      fontFamily:
+        svaTypography?.textStyle.authTinyLabel.fontFamily ?? "Inter_600SemiBold",
+      fontSize: 11,
+      lineHeight: 16,
+      color: theme.textSecondary,
+      marginTop: 12,
+    },
+    errorTitle: {
+      ...typography.h3,
+      color: "#F7C48B",
+    },
+    errorText: {
+      ...typography.body,
+      color: "#F4D8B5",
+      marginTop: 8,
     },
     ctaButton: {
       width: "100%",

--- a/features/self-care/screens/MeditationPlayerScreen.tsx
+++ b/features/self-care/screens/MeditationPlayerScreen.tsx
@@ -116,8 +116,8 @@ export default function MeditationPlayerScreen() {
   const progress = Math.min(positionMillis / durationMillis, 1);
 
   const playbackSource = useMemo(
-    () => resolveMeditationPlaybackSource(meditationId),
-    [meditationId]
+    () => resolveMeditationPlaybackSource(meditationId, template.source ?? null),
+    [meditationId, template.source]
   );
   const heroImage = useMemo(
     () => resolveMeditationPlaybackCover(template),

--- a/features/self-care/screens/MeditationPlayerScreen.tsx
+++ b/features/self-care/screens/MeditationPlayerScreen.tsx
@@ -37,7 +37,9 @@ import {
 } from "@/features/self-care/utils/meditationPlayback";
 import {
   formatMeditationTagLabel,
+  hydrateMeditationTemplate,
   mockMeditationRecommendations,
+  type MeditationRouteParams,
   type MeditationTemplate,
 } from "@/features/self-care/utils/meditationLibrary";
 import type {
@@ -47,12 +49,7 @@ import type {
   TypographyTokens,
 } from "@/theme/types";
 
-type MeditationPlayerParams = {
-  meditationId?: string | string[];
-  meditationTitle?: string | string[];
-  meditationDescription?: string | string[];
-  meditationDurationLabel?: string | string[];
-};
+type MeditationPlayerParams = MeditationRouteParams;
 
 const parseParam = (value?: string | string[]) => {
   if (Array.isArray(value)) return value[0];
@@ -80,19 +77,19 @@ export default function MeditationPlayerScreen() {
     useContext(ThemeContext);
 
   const meditationId = parseParam(params.meditationId) ?? "moonlit-reset";
-  const template = useMemo(
-    () =>
-      mockMeditationRecommendations.find((item) => item.id === meditationId) ??
-      mockMeditationRecommendations[0],
-    [meditationId]
-  );
+  const fallbackMeditation = useMemo<MeditationTemplate>(() => {
+    return (
+      mockMeditationRecommendations.find(
+        (item) => item.id === meditationId || item.slug === meditationId
+      ) ?? mockMeditationRecommendations[0]
+    );
+  }, [meditationId]);
 
-  const meditationTitle =
-    parseParam(params.meditationTitle) ?? template.title ?? "Meditation";
-  const meditationDescription =
-    parseParam(params.meditationDescription) ?? template.description;
-  const meditationDurationLabel =
-    parseParam(params.meditationDurationLabel) ?? template.durationLabel;
+  const template = hydrateMeditationTemplate(params, fallbackMeditation);
+
+  const meditationTitle = template.title ?? "Meditation";
+  const meditationDescription = template.description;
+  const meditationDurationLabel = template.durationLabel;
   const meditationMeta = useMemo(() => buildMeditationMeta(template), [template]);
 
   const styles = useMemo(

--- a/features/self-care/screens/MeditationScreen.tsx
+++ b/features/self-care/screens/MeditationScreen.tsx
@@ -1,6 +1,7 @@
 import React, {
   useCallback,
   useContext,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useState,
@@ -20,12 +21,20 @@ import NimbusUltraFeaturedCard from "@/components/layout/NimbusUltraFeaturedCard
 import ThemeContext from "@/contexts/ThemeContext";
 import PillFilters from "@/components/ui/PillFilters";
 import { ScreenView } from "@/components/ui/theme-components/ScreenView";
+import {
+  MeditationFeaturedSkeleton,
+  MeditationListSkeleton,
+} from "@/features/self-care/components/meditation/MeditationSkeletonSections";
 import MeditationTemplateCard from "@/features/self-care/components/meditation/MeditationTemplateCard";
+import { getWellnessContentList } from "@/features/self-care/services/selfCareService";
 import {
   buildMeditationFilterOptions,
+  buildMeditationRouteParams,
   filterMeditationTemplates,
   formatMeditationTagLabel,
-  mockMeditationRecommendations,
+  fallbackMeditationTemplates,
+  mapMeditationTemplate,
+  type MeditationTemplate,
 } from "@/features/self-care/utils/meditationLibrary";
 import { ROUTES } from "@/constants/routes";
 import type {
@@ -40,8 +49,11 @@ export const MeditationScreen: React.FC = () => {
   const { newTheme: theme, svaTypography, spacing, typography } =
     useContext(ThemeContext);
 
-  const templates = mockMeditationRecommendations;
+  const [templates, setTemplates] = useState<MeditationTemplate[]>(
+    fallbackMeditationTemplates
+  );
   const [selectedTag, setSelectedTag] = useState<string>("all");
+  const [isLoading, setIsLoading] = useState(true);
 
   const styles = useMemo(
     () => styling(theme, svaTypography, spacing, typography),
@@ -52,10 +64,58 @@ export const MeditationScreen: React.FC = () => {
     navigation.setOptions({ headerShown: false });
   }, [navigation]);
 
+  useEffect(() => {
+    let active = true;
+
+    const loadMeditationContent = async () => {
+      setIsLoading(true);
+
+      try {
+        const result = await getWellnessContentList({ modality: "meditation" });
+        const sourceItems =
+          Array.isArray(result.data) && result.data.length > 0
+            ? result.data
+            : null;
+
+        const normalized = sourceItems
+          ? sourceItems.map((item, index) => mapMeditationTemplate(item, index))
+          : fallbackMeditationTemplates;
+
+        if (active) {
+          setTemplates(normalized);
+        }
+      } catch (error) {
+        console.warn("Unable to load meditation content:", error);
+        if (active) {
+          setTemplates(fallbackMeditationTemplates);
+        }
+      } finally {
+        if (active) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadMeditationContent();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
   const filterOptions = useMemo(
     () => buildMeditationFilterOptions(templates),
     [templates]
   );
+
+  useEffect(() => {
+    if (
+      selectedTag !== "all" &&
+      !filterOptions.some((option) => option.value === selectedTag)
+    ) {
+      setSelectedTag("all");
+    }
+  }, [filterOptions, selectedTag]);
 
   const visibleTemplates = useMemo(
     () => filterMeditationTemplates(templates, selectedTag),
@@ -80,13 +140,32 @@ export const MeditationScreen: React.FC = () => {
     filterOptions.find((option) => option.value === selectedTag)?.label ??
     "All Modes";
 
-
-  const openMeditationDetail = useCallback((meditationId: string) => {
+  const openMeditationDetail = useCallback((template: MeditationTemplate) => {
     router.push({
       pathname: ROUTES.AUTH.SELF_CARE_MEDITATION_DETAIL,
-      params: { meditationId },
+      params: buildMeditationRouteParams(template),
     });
   }, []);
+
+  if (isLoading) {
+    return (
+      <ScreenView bgColor={theme.background} style={styles.screen}>
+        <View style={styles.root}>
+          <AppHeader
+            title="Quiet Current"
+            subtitle="Curated recommendations for breath, sleep, and reset."
+            onBack={() => router.back()}
+            containerStyle={styles.header}
+          />
+
+          <View style={styles.loadingContent}>
+            <MeditationFeaturedSkeleton />
+            <MeditationListSkeleton />
+          </View>
+        </View>
+      </ScreenView>
+    );
+  }
 
   return (
     <ScreenView bgColor={theme.background} style={styles.screen}>
@@ -126,7 +205,7 @@ export const MeditationScreen: React.FC = () => {
                     badge="Curated pick"
                     tint="rgba(163,190,140,0.12)"
                     accent={theme.chart2 ?? theme.accent}
-                    onPress={() => openMeditationDetail(featuredTemplate.id)}
+                    onPress={() => openMeditationDetail(featuredTemplate)}
                   />
                 </View>
               ) : null}
@@ -167,7 +246,7 @@ export const MeditationScreen: React.FC = () => {
           renderItem={({ item }) => (
             <MeditationTemplateCard
               item={item}
-              onPress={() => openMeditationDetail(item.id)}
+              onPress={() => openMeditationDetail(item)}
             />
           )}
           ListEmptyComponent={
@@ -208,6 +287,9 @@ const styling = (
     },
     header: {
       marginBottom: spacing.md,
+    },
+    loadingContent: {
+      flex: 1,
     },
     listContent: {
       paddingBottom: spacing.xl * 3,

--- a/features/self-care/screens/MeditationScreen.tsx
+++ b/features/self-care/screens/MeditationScreen.tsx
@@ -123,10 +123,7 @@ export const MeditationScreen: React.FC = () => {
   );
 
   const featuredTemplate = useMemo(
-    () =>
-      templates.find((item) => item.id === "moonlit-reset") ??
-      visibleTemplates[0] ??
-      templates[0],
+    () => visibleTemplates[0] ?? templates[0],
     [visibleTemplates, templates]
   );
 

--- a/features/self-care/screens/__tests__/MeditationDetailScreen.test.tsx
+++ b/features/self-care/screens/__tests__/MeditationDetailScreen.test.tsx
@@ -8,8 +8,9 @@ import { ROUTES } from "../../../../constants/routes";
 import MeditationDetailScreen from "../MeditationDetailScreen";
 import {
   buildMeditationRouteParams,
-  mockMeditationRecommendations,
+  mapMeditationTemplate,
 } from "../../utils/meditationLibrary";
+import { getWellnessContentDetail } from "../../services/selfCareService";
 
 const mockPush = jest.fn();
 const mockBack = jest.fn();
@@ -17,7 +18,7 @@ const mockSetOptions = jest.fn();
 const mockShare = jest.fn();
 
 let mockParams = {
-  meditationId: "moonlit-reset",
+  meditationId: "1",
 };
 
 jest.mock("expo-router", () => ({
@@ -67,6 +68,15 @@ jest.mock("../../../../components/ui/theme-components/NimbusButton", () => {
   };
 });
 
+jest.mock("../../services/selfCareService", () => {
+  const actual = jest.requireActual("../../services/selfCareService");
+
+  return {
+    ...actual,
+    getWellnessContentDetail: jest.fn(),
+  };
+});
+
 const theme = getTheme("sva");
 const themeValue = {
   theme: "sva",
@@ -83,6 +93,62 @@ const themeValue = {
   activeTheme: theme,
 };
 
+const apiDetail = {
+  id: 1,
+  title: "Relaxing Meditation",
+  duration: "2.5 min",
+  category: "Relaxation",
+  image:
+    "https://images.unsplash.com/photo-1506126613408-eca07ce68773?q=80&w=1200&auto=format&fit=crop",
+  audio: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3",
+  description:
+    "A gentle practice to release tension and find inner calm.",
+  longDescription:
+    "This practice uses a Sattva-forward approach to settle mental noise, soften muscular holding, and anchor awareness in the present moment.",
+  guidance:
+    "Focus on a slow inhale and a longer exhale. Let the body feel supported, then allow the mind to settle into stillness without forcing concentration.",
+  date: "Oct 24, 2026",
+  dosha: "Vata",
+  level: "Beginner",
+  rating: 4.9,
+  reviews: 128,
+  tags: ["Calm", "Vata Balancing", "Vedic Wisdom", "Visualization"],
+  instructor: {
+    name: "Dr. Amara Sethi",
+    role: "Lead Research & Vedic Scholar",
+    bio: "Dr. Sethi is a lead research scholar specializing in Vedic psychology and contemplative neuroscience.",
+    image:
+      "https://images.unsplash.com/photo-1544367563-12123d896889?q=80&w=200&auto=format&fit=crop",
+  },
+  benefits: [
+    {
+      id: 1,
+      title: "Cognitive Clarity",
+      text: "Settles mental noise so attention feels less fragmented and easier to direct.",
+    },
+    {
+      id: 2,
+      title: "Nervous System Regulation",
+      text: "Encourages a slower breathing rhythm that supports parasympathetic recovery.",
+    },
+    {
+      id: 3,
+      title: "Ojas Restoration",
+      text: "Creates a quiet, restorative state that feels nourishing rather than stimulating.",
+    },
+  ],
+  scientificSynthesis: {
+    title: "Structural Resilience & Network Stability",
+    text: "Mindfulness practice is associated with stronger attentional control and a more stable response to stress over time.",
+    source:
+      "Massachusetts General Hospital. (2025). Mindfulness meditation and network neuroscience review.",
+  },
+};
+
+const mockGetWellnessContentDetail = getWellnessContentDetail as jest.MockedFunction<
+  typeof getWellnessContentDetail
+>;
+
 const getTextContent = (node: any) =>
   Array.isArray(node.props.children)
     ? node.props.children.join("")
@@ -93,15 +159,18 @@ const hasText = (tree: renderer.ReactTestRenderer, value: string) =>
     .findAllByType(Text)
     .some((node) => getTextContent(node) === value);
 
-function renderScreen() {
+async function renderScreen() {
   let tree!: renderer.ReactTestRenderer;
 
-  act(() => {
+  await act(async () => {
     tree = renderer.create(
       <ThemeContext.Provider value={themeValue as any}>
         <MeditationDetailScreen />
       </ThemeContext.Provider>
     );
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   return tree;
@@ -111,8 +180,13 @@ describe("MeditationDetailScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockParams = {
-      meditationId: "moonlit-reset",
+      meditationId: "1",
     };
+    mockGetWellnessContentDetail.mockResolvedValue({
+      success: true,
+      message: "Wellness content retrieved successfully.",
+      data: apiDetail as any,
+    });
     jest.spyOn(Share, "share").mockImplementation(mockShare);
     mockShare.mockResolvedValue({ action: "sharedAction" });
   });
@@ -121,22 +195,28 @@ describe("MeditationDetailScreen", () => {
     jest.restoreAllMocks();
   });
 
-  it("renders the premium meditation detail layout", () => {
-    const tree = renderScreen();
+  it("loads the wellness content detail and renders the enriched meditation layout", async () => {
+    const tree = await renderScreen();
 
     expect(mockSetOptions).toHaveBeenCalledWith({
       headerShown: false,
     });
+    expect(mockGetWellnessContentDetail).toHaveBeenCalledWith(1);
 
     expect(hasText(tree, "Meditation Prelude")).toBe(true);
-    expect(hasText(tree, "Moonlit Reset")).toBe(true);
+    expect(hasText(tree, "Relaxing Meditation")).toBe(true);
     expect(hasText(tree, "ABOUT THIS SESSION")).toBe(true);
+    expect(hasText(tree, "GUIDANCE")).toBe(true);
+    expect(hasText(tree, "INSTRUCTOR")).toBe(true);
     expect(hasText(tree, "BENEFITS")).toBe(true);
+    expect(hasText(tree, "SCIENTIFIC SYNTHESIS")).toBe(true);
     expect(hasText(tree, "Start Meditation")).toBe(true);
+    expect(hasText(tree, "Dr. Amara Sethi")).toBe(true);
+    expect(hasText(tree, "Cognitive Clarity")).toBe(true);
   });
 
-  it("toggles favorite state and shares the meditation", () => {
-    const tree = renderScreen();
+  it("toggles favorite state, shares the fetched meditation, and forwards the detail payload to the player", async () => {
+    const tree = await renderScreen();
 
     const favoriteButton = tree.root.findByProps({
       accessibilityLabel: "Add to favorites",
@@ -161,12 +241,9 @@ describe("MeditationDetailScreen", () => {
     });
 
     expect(mockShare).toHaveBeenCalledWith({
-      message: "Moonlit Reset · A calm reset for the nervous system when the day has been too loud.",
+      message:
+        "Relaxing Meditation · A gentle practice to release tension and find inner calm.",
     });
-  });
-
-  it("starts the meditation session from the detail screen", () => {
-    const tree = renderScreen();
 
     const startButton = tree.root.findByProps({
       accessibilityLabel: "Start Meditation",
@@ -176,12 +253,11 @@ describe("MeditationDetailScreen", () => {
       startButton.props.onPress();
     });
 
+    const expectedTemplate = mapMeditationTemplate(apiDetail as any, 0);
+
     expect(mockPush).toHaveBeenCalledWith({
       pathname: ROUTES.AUTH.SELF_CARE_MEDITATION_PLAYER,
-      params: buildMeditationRouteParams(
-        mockMeditationRecommendations.find((item) => item.id === "moonlit-reset") ??
-          mockMeditationRecommendations[0]
-      ),
+      params: buildMeditationRouteParams(expectedTemplate),
     });
   });
 });

--- a/features/self-care/screens/__tests__/MeditationDetailScreen.test.tsx
+++ b/features/self-care/screens/__tests__/MeditationDetailScreen.test.tsx
@@ -6,6 +6,10 @@ import ThemeContext from "../../../../contexts/ThemeContext";
 import { getTheme } from "../../../../theme";
 import { ROUTES } from "../../../../constants/routes";
 import MeditationDetailScreen from "../MeditationDetailScreen";
+import {
+  buildMeditationRouteParams,
+  mockMeditationRecommendations,
+} from "../../utils/meditationLibrary";
 
 const mockPush = jest.fn();
 const mockBack = jest.fn();
@@ -174,13 +178,10 @@ describe("MeditationDetailScreen", () => {
 
     expect(mockPush).toHaveBeenCalledWith({
       pathname: ROUTES.AUTH.SELF_CARE_MEDITATION_PLAYER,
-      params: {
-        meditationId: "moonlit-reset",
-        meditationTitle: "Moonlit Reset",
-        meditationDescription:
-          "A calm reset for the nervous system when the day has been too loud.",
-        meditationDurationLabel: "7 min",
-      },
+      params: buildMeditationRouteParams(
+        mockMeditationRecommendations.find((item) => item.id === "moonlit-reset") ??
+          mockMeditationRecommendations[0]
+      ),
     });
   });
 });

--- a/features/self-care/screens/__tests__/MeditationPlayerScreen.test.tsx
+++ b/features/self-care/screens/__tests__/MeditationPlayerScreen.test.tsx
@@ -16,11 +16,12 @@ const mockSetAudioModeAsync = jest.fn();
 const mockCreateAsync = jest.fn();
 
 let mockParams = {
-  meditationId: "moonlit-reset",
-  meditationTitle: "Moonlit Reset",
+  meditationId: "1",
+  meditationTitle: "Relaxing Meditation",
   meditationDescription:
-    "A calm reset for the nervous system when the day has been too loud.",
-  meditationDurationLabel: "7 min",
+    "A gentle practice to release tension and find inner calm.",
+  meditationDurationLabel: "2.5 min",
+  meditationSource: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3",
 };
 
 let playbackStatusCallback: ((status: any) => void) | null = null;
@@ -139,11 +140,13 @@ describe("MeditationPlayerScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockParams = {
-      meditationId: "moonlit-reset",
-      meditationTitle: "Moonlit Reset",
+      meditationId: "1",
+      meditationTitle: "Relaxing Meditation",
       meditationDescription:
-        "A calm reset for the nervous system when the day has been too loud.",
-      meditationDurationLabel: "7 min",
+        "A gentle practice to release tension and find inner calm.",
+      meditationDurationLabel: "2.5 min",
+      meditationSource:
+        "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3",
     };
     playbackStatusCallback = null;
 
@@ -177,7 +180,10 @@ describe("MeditationPlayerScreen", () => {
 
     expect(mockSetAudioModeAsync).toHaveBeenCalled();
     expect(mockCreateAsync).toHaveBeenCalledWith(
-      resolveMeditationPlaybackSource("moonlit-reset"),
+      resolveMeditationPlaybackSource(
+        "1",
+        "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3"
+      ),
       expect.objectContaining({
         shouldPlay: true,
       }),
@@ -187,7 +193,7 @@ describe("MeditationPlayerScreen", () => {
     expect(hasText(tree, "SVA")).toBe(false);
     expect(hasText(tree, "Meditation")).toBe(true);
     expect(hasText(tree, "NIMBUS ORIGINAL MEDITATION")).toBe(true);
-    expect(hasText(tree, "Moonlit Reset")).toBe(true);
+    expect(hasText(tree, "Relaxing Meditation")).toBe(true);
   });
 
   it("pauses, seeks, shares, and returns to the library", async () => {
@@ -222,7 +228,7 @@ describe("MeditationPlayerScreen", () => {
     expect(mockSound.setPositionAsync).toHaveBeenCalledWith(15000);
     expect(mockShare).toHaveBeenCalledWith({
       message:
-        "Moonlit Reset · A calm reset for the nervous system when the day has been too loud.",
+        "Relaxing Meditation · A gentle practice to release tension and find inner calm.",
     });
     expect(mockPush).toHaveBeenCalledWith(ROUTES.AUTH.SELF_CARE_MEDITATION);
   });

--- a/features/self-care/screens/__tests__/MeditationScreen.test.tsx
+++ b/features/self-care/screens/__tests__/MeditationScreen.test.tsx
@@ -6,6 +6,11 @@ import ThemeContext from "../../../../contexts/ThemeContext";
 import { getTheme } from "../../../../theme";
 import { ROUTES } from "../../../../constants/routes";
 import MeditationScreen from "../MeditationScreen";
+import {
+  buildMeditationRouteParams,
+  mapMeditationTemplate,
+} from "../../utils/meditationLibrary";
+import { getWellnessContentList } from "../../services/selfCareService";
 
 const mockPush = jest.fn();
 const mockBack = jest.fn();
@@ -25,6 +30,15 @@ jest.mock("react-native-safe-area-context", () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 
+jest.mock("../../services/selfCareService", () => {
+  const actual = jest.requireActual("../../services/selfCareService");
+
+  return {
+    ...actual,
+    getWellnessContentList: jest.fn(),
+  };
+});
+
 const theme = getTheme("sva");
 const themeValue = {
   theme: "sva",
@@ -41,6 +55,41 @@ const themeValue = {
   activeTheme: theme,
 };
 
+const wellnessContent = [
+  {
+    id: 1,
+    slug: "relaxing-meditation",
+    title: "Relaxing Meditation",
+    modality: "meditation",
+    category: "Relaxation",
+    duration: "2.5 min",
+    image: "https://example.com/relaxing.png",
+    rating: 4.9,
+    reviews: 128,
+    tags: ["Calm", "Vata Balancing", "Vedic Wisdom", "Visualization"],
+    level: "Beginner",
+    dosha: "Vata",
+  },
+  {
+    id: 2,
+    slug: "sleep-soothing-meditation",
+    title: "Sleep Soothing Meditation",
+    modality: "meditation",
+    category: "Sleep",
+    duration: "5 min",
+    image: "https://example.com/sleep.png",
+    rating: 4.85,
+    reviews: 96,
+    tags: ["Sleep", "Wind Down", "Rest", "Evening"],
+    level: "All Levels",
+    dosha: "Kapha",
+  },
+];
+
+const mockGetWellnessContentList = getWellnessContentList as jest.MockedFunction<
+  typeof getWellnessContentList
+>;
+
 const hasText = (tree: renderer.ReactTestRenderer, value: string) =>
   tree.root
     .findAllByType(Text)
@@ -50,15 +99,18 @@ const hasText = (tree: renderer.ReactTestRenderer, value: string) =>
         : node.props.children === value
     );
 
-function renderScreen() {
+async function renderScreen() {
   let tree!: renderer.ReactTestRenderer;
 
-  act(() => {
+  await act(async () => {
     tree = renderer.create(
       <ThemeContext.Provider value={themeValue as any}>
         <MeditationScreen />
       </ThemeContext.Provider>
     );
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   return tree;
@@ -67,35 +119,41 @@ function renderScreen() {
 describe("MeditationScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetWellnessContentList.mockResolvedValue({
+      success: true,
+      message: "Wellness content retrieved successfully.",
+      data: wellnessContent as any,
+      pagination: {
+        count: 2,
+        next: null,
+        previous: null,
+        page: 1,
+        page_size: 100,
+        total_pages: 1,
+        results_count: 2,
+      },
+    });
   });
 
-  it("renders the curated recommendation above the meditation list", () => {
-    const tree = renderScreen();
+  it("renders the API-backed meditation list and opens the featured meditation with hydrated params", async () => {
+    const tree = await renderScreen();
 
     expect(mockSetOptions).toHaveBeenCalledWith({
       headerShown: false,
     });
+    expect(mockGetWellnessContentList).toHaveBeenCalledWith({
+      modality: "meditation",
+    });
 
     expect(hasText(tree, "Quiet Current")).toBe(true);
     expect(hasText(tree, "CURATED RECOMMENDATION")).toBe(true);
-    expect(hasText(tree, "Moonlit Reset")).toBe(true);
+    expect(hasText(tree, "Relaxing Meditation")).toBe(true);
+    expect(hasText(tree, "Sleep Soothing Meditation")).toBe(true);
     expect(hasText(tree, "Curated pick")).toBe(true);
-    expect(hasText(tree, "Sleep Drift")).toBe(true);
-    expect(hasText(tree, "Focus Lantern")).toBe(true);
     expect(hasText(tree, "Open")).toBe(true);
 
-    const list = tree.root.findByProps({
-      testID: "meditation-library-list",
-    });
-
-    expect(list.props.horizontal).not.toBe(true);
-  });
-
-  it("opens the meditation detail page from the curated recommendation", () => {
-    const tree = renderScreen();
-
     const featuredCard = tree.root.findByProps({
-      accessibilityLabel: "Open Moonlit Reset",
+      accessibilityLabel: "Open Relaxing Meditation",
     });
 
     act(() => {
@@ -104,14 +162,14 @@ describe("MeditationScreen", () => {
 
     expect(mockPush).toHaveBeenCalledWith({
       pathname: ROUTES.AUTH.SELF_CARE_MEDITATION_DETAIL,
-      params: {
-        meditationId: "moonlit-reset",
-      },
+      params: buildMeditationRouteParams(
+        mapMeditationTemplate(wellnessContent[0] as any, 0)
+      ),
     });
   });
 
-  it("filters the library list by tag while keeping the curated card", () => {
-    const tree = renderScreen();
+  it("filters the library by tag and opens a library item with the API payload", async () => {
+    const tree = await renderScreen();
 
     const sleepFilter = tree.root.findByProps({
       accessibilityLabel: "Sleep",
@@ -122,28 +180,22 @@ describe("MeditationScreen", () => {
     });
 
     expect(hasText(tree, "Sleep collection")).toBe(true);
-    expect(hasText(tree, "Sleep Drift")).toBe(true);
-    expect(hasText(tree, "Moonlit Reset")).toBe(true);
-    expect(hasText(tree, "Focus Lantern")).toBe(false);
-    expect(hasText(tree, "Soft Release")).toBe(false);
-  });
+    expect(hasText(tree, "Sleep Soothing Meditation")).toBe(true);
+    expect(hasText(tree, "Relaxing Meditation")).toBe(false);
 
-  it("opens the meditation detail page from a library card", () => {
-    const tree = renderScreen();
-
-    const listCard = tree.root.findByProps({
-      accessibilityLabel: "Open Sleep Drift",
+    const sleepCard = tree.root.findByProps({
+      accessibilityLabel: "Open Sleep Soothing Meditation",
     });
 
     act(() => {
-      listCard.props.onPress();
+      sleepCard.props.onPress();
     });
 
     expect(mockPush).toHaveBeenCalledWith({
       pathname: ROUTES.AUTH.SELF_CARE_MEDITATION_DETAIL,
-      params: {
-        meditationId: "sleep-drift",
-      },
+      params: buildMeditationRouteParams(
+        mapMeditationTemplate(wellnessContent[1] as any, 1)
+      ),
     });
   });
 });

--- a/features/self-care/services/__tests__/selfCareService.test.ts
+++ b/features/self-care/services/__tests__/selfCareService.test.ts
@@ -1,0 +1,62 @@
+import axios from "axios";
+
+import { API_ENDPOINTS } from "@/config/apiConfig";
+
+import { getWellnessContentList } from "../selfCareService";
+
+jest.mock("axios", () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("selfCareService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("fetches meditation wellness content with the modality query", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: "Wellness content retrieved successfully.",
+        data: [
+          {
+            id: 1,
+            slug: "relaxing-meditation",
+            title: "Relaxing Meditation",
+            modality: "meditation",
+            category: "Relaxation",
+            duration: "2.5 min",
+            image: "https://example.com/relaxing.png",
+            rating: 4.9,
+            reviews: 128,
+            tags: ["Calm", "Vata Balancing"],
+            level: "Beginner",
+            dosha: "Vata",
+          },
+        ],
+        pagination: {
+          count: 1,
+          next: null,
+          previous: null,
+          page: 1,
+          page_size: 100,
+          total_pages: 1,
+          results_count: 1,
+        },
+      },
+    });
+
+    const result = await getWellnessContentList({ modality: "meditation" });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      API_ENDPOINTS.getWellnessContent,
+      { params: { modality: "meditation" } }
+    );
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].slug).toBe("relaxing-meditation");
+  });
+});

--- a/features/self-care/services/__tests__/selfCareService.test.ts
+++ b/features/self-care/services/__tests__/selfCareService.test.ts
@@ -2,7 +2,10 @@ import axios from "axios";
 
 import { API_ENDPOINTS } from "@/config/apiConfig";
 
-import { getWellnessContentList } from "../selfCareService";
+import {
+  getWellnessContentDetail,
+  getWellnessContentList,
+} from "../selfCareService";
 
 jest.mock("axios", () => ({
   get: jest.fn(),
@@ -58,5 +61,61 @@ describe("selfCareService", () => {
     expect(result.success).toBe(true);
     expect(result.data).toHaveLength(1);
     expect(result.data[0].slug).toBe("relaxing-meditation");
+  });
+
+  it("fetches a single wellness content detail by id", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: "Wellness content retrieved successfully.",
+        data: {
+          id: 1,
+          title: "Relaxing Meditation",
+          duration: "2.5 min",
+          category: "Relaxation",
+          image: "https://example.com/relaxing.png",
+          audio: "https://example.com/relaxing.mp3",
+          description: "A gentle practice to release tension and find inner calm.",
+          longDescription:
+            "This practice uses a Sattva-forward approach to settle mental noise.",
+          guidance:
+            "Focus on a slow inhale and a longer exhale. Let the body feel supported.",
+          date: "Oct 24, 2026",
+          dosha: "Vata",
+          level: "Beginner",
+          rating: 4.9,
+          reviews: 128,
+          tags: ["Calm", "Vata Balancing"],
+          instructor: {
+            name: "Dr. Amara Sethi",
+            role: "Lead Research & Vedic Scholar",
+            bio: "Dr. Sethi is a lead research scholar specializing in Vedic psychology and contemplative neuroscience.",
+            image: "https://example.com/instructor.png",
+          },
+          benefits: [
+            {
+              id: 1,
+              title: "Cognitive Clarity",
+              text: "Settles mental noise so attention feels less fragmented.",
+            },
+          ],
+          scientificSynthesis: {
+            title: "Structural Resilience & Network Stability",
+            text: "Mindfulness practice is associated with stronger attentional control.",
+            source:
+              "Massachusetts General Hospital. (2025). Mindfulness meditation and network neuroscience review.",
+          },
+        },
+      },
+    });
+
+    const result = await getWellnessContentDetail(1);
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      API_ENDPOINTS.getWellnessContentDetail(1)
+    );
+    expect(result.success).toBe(true);
+    expect(result.data.audio).toBe("https://example.com/relaxing.mp3");
+    expect(result.data.instructor.name).toBe("Dr. Amara Sethi");
   });
 });

--- a/features/self-care/services/selfCareService.ts
+++ b/features/self-care/services/selfCareService.ts
@@ -5,6 +5,7 @@ import {
   JournalListResponse,
   JournalSubmitRequest,
   JournalSubmitResponse,
+  WellnessContentDetailResponse,
   MeditationVideoListResponse,
   WellnessContentResponse,
   WorkoutVideoListResponse,
@@ -113,6 +114,18 @@ export const getWellnessContentList = async (params?: {
       API_ENDPOINTS.getWellnessContent,
       { params }
     );
+    return response.data;
+  } catch (error: any) {
+    throw error.response ? error.response.data : error.message;
+  }
+};
+
+export const getWellnessContentDetail = async (
+  id: number | string
+): Promise<WellnessContentDetailResponse> => {
+  try {
+    const response: AxiosResponse<WellnessContentDetailResponse> =
+      await axios.get(API_ENDPOINTS.getWellnessContentDetail(id));
     return response.data;
   } catch (error: any) {
     throw error.response ? error.response.data : error.message;

--- a/features/self-care/services/selfCareService.ts
+++ b/features/self-care/services/selfCareService.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse, AxiosError } from "axios";
+import axios, { AxiosResponse } from "axios";
 import { API_ENDPOINTS } from "@/config/apiConfig";
 import {
   JournalEntryListResponse,
@@ -6,7 +6,7 @@ import {
   JournalSubmitRequest,
   JournalSubmitResponse,
   MeditationVideoListResponse,
-  MentalTestListResponse,
+  WellnessContentResponse,
   WorkoutVideoListResponse,
 } from "@/features/self-care/types/selfCareTypes";
 
@@ -104,3 +104,17 @@ export const getMeditationAudioList =
       throw error.response ? error.response.data : error.message;
     }
   };
+
+export const getWellnessContentList = async (params?: {
+  modality?: string;
+}): Promise<WellnessContentResponse> => {
+  try {
+    const response: AxiosResponse<WellnessContentResponse> = await axios.get(
+      API_ENDPOINTS.getWellnessContent,
+      { params }
+    );
+    return response.data;
+  } catch (error: any) {
+    throw error.response ? error.response.data : error.message;
+  }
+};

--- a/features/self-care/types/selfCareTypes.ts
+++ b/features/self-care/types/selfCareTypes.ts
@@ -34,8 +34,6 @@ type ExerciseCategory = "cardio" | "strength" | "stretching" | "full_body";
 
 type DifficultyLevel = "easy" | "medium" | "hard";
 
-type MetricType = "time" | "reps";
-
 export interface Exercise {
   id: string;
   name: string; // "Dumbbell Shoulder Press"
@@ -159,6 +157,38 @@ export interface MeditationListItem {
 export interface MeditationVideoListResponse {
   data: MeditationListItem[];
   success: boolean;
+}
+
+export interface WellnessContentItem {
+  id: number;
+  slug: string;
+  title: string;
+  modality: string;
+  category: string;
+  duration: string;
+  image: string;
+  rating: number;
+  reviews: number;
+  tags: string[];
+  level: string;
+  dosha: string;
+}
+
+export interface WellnessContentPagination {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  page: number;
+  page_size: number;
+  total_pages: number;
+  results_count: number;
+}
+
+export interface WellnessContentResponse {
+  success: boolean;
+  message: string;
+  data: WellnessContentItem[];
+  pagination?: WellnessContentPagination;
 }
 
 export type EnrichedMeditation = Meditations & {

--- a/features/self-care/types/selfCareTypes.ts
+++ b/features/self-care/types/selfCareTypes.ts
@@ -161,7 +161,7 @@ export interface MeditationVideoListResponse {
 
 export interface WellnessContentItem {
   id: number;
-  slug: string;
+  slug?: string;
   title: string;
   modality: string;
   category: string;
@@ -172,6 +172,7 @@ export interface WellnessContentItem {
   tags: string[];
   level: string;
   dosha: string;
+  description?: string;
 }
 
 export interface WellnessContentPagination {
@@ -189,6 +190,42 @@ export interface WellnessContentResponse {
   message: string;
   data: WellnessContentItem[];
   pagination?: WellnessContentPagination;
+}
+
+export interface WellnessContentInstructor {
+  name: string;
+  role: string;
+  bio: string;
+  image: string;
+}
+
+export interface WellnessContentBenefit {
+  id: number;
+  title: string;
+  text: string;
+}
+
+export interface WellnessContentScientificSynthesis {
+  title: string;
+  text: string;
+  source: string;
+}
+
+export interface WellnessContentDetailItem extends WellnessContentItem {
+  audio: string;
+  description: string;
+  longDescription: string;
+  guidance: string;
+  date: string;
+  instructor: WellnessContentInstructor;
+  benefits: WellnessContentBenefit[];
+  scientificSynthesis: WellnessContentScientificSynthesis;
+}
+
+export interface WellnessContentDetailResponse {
+  success: boolean;
+  message: string;
+  data: WellnessContentDetailItem;
 }
 
 export type EnrichedMeditation = Meditations & {

--- a/features/self-care/utils/__tests__/meditationLibrary.test.ts
+++ b/features/self-care/utils/__tests__/meditationLibrary.test.ts
@@ -1,6 +1,8 @@
 import {
   buildMeditationFilterOptions,
+  buildMeditationRouteParams,
   filterMeditationTemplates,
+  hydrateMeditationTemplate,
   mapMeditationTemplate,
   mockMeditationRecommendations,
 } from "../meditationLibrary";
@@ -10,6 +12,7 @@ describe("meditationLibrary", () => {
     const template = mapMeditationTemplate(
       {
         id: 19,
+        slug: "moon-breath",
         title: "Moon Breath",
         description: "Slow the inhale and exhale until the room softens.",
         category: "breathwork",
@@ -19,11 +22,50 @@ describe("meditationLibrary", () => {
       0
     );
 
-    expect(template.id).toBe("19");
+    expect(template.id).toBe("moon-breath");
+    expect(template.slug).toBe("moon-breath");
     expect(template.title).toBe("Moon Breath");
     expect(template.durationLabel).toBe("6 min");
     expect(template.tags).toContain("breath");
     expect(template.source).toBe("https://example.com/moon-breath.mp3");
+  });
+
+  it("normalizes API wellness content into meditation templates and route params", () => {
+    const template = mapMeditationTemplate(
+      {
+        id: 1,
+        slug: "relaxing-meditation",
+        title: "Relaxing Meditation",
+        modality: "meditation",
+        category: "Relaxation",
+        duration: "2.5 min",
+        image: "https://example.com/relaxing.png",
+        rating: 4.9,
+        reviews: 128,
+        tags: ["Calm", "Vata Balancing", "Vedic Wisdom", "Visualization"],
+        level: "Beginner",
+        dosha: "Vata",
+      },
+      0
+    );
+
+    const params = buildMeditationRouteParams(template);
+    const hydrated = hydrateMeditationTemplate(params, template);
+
+    expect(template.id).toBe("relaxing-meditation");
+    expect(template.slug).toBe("relaxing-meditation");
+    expect(template.durationLabel).toBe("2.5 min");
+    expect(template.tag).toBe("calm");
+    expect(template.tags).toContain("calm");
+    expect(template.tags).toContain("vata-balancing");
+    expect(template.level).toBe("Beginner");
+    expect(template.dosha).toBe("Vata");
+    expect(template.rating).toBe(4.9);
+    expect(template.reviews).toBe(128);
+    expect(params.meditationId).toBe("relaxing-meditation");
+    expect(params.meditationImage).toBe("https://example.com/relaxing.png");
+    expect(hydrated.title).toBe("Relaxing Meditation");
+    expect(hydrated.durationLabel).toBe("2.5 min");
   });
 
   it("builds unique filters and filters templates by tag", () => {

--- a/features/self-care/utils/__tests__/meditationLibrary.test.ts
+++ b/features/self-care/utils/__tests__/meditationLibrary.test.ts
@@ -22,7 +22,7 @@ describe("meditationLibrary", () => {
       0
     );
 
-    expect(template.id).toBe("moon-breath");
+    expect(template.id).toBe("19");
     expect(template.slug).toBe("moon-breath");
     expect(template.title).toBe("Moon Breath");
     expect(template.durationLabel).toBe("6 min");
@@ -30,7 +30,7 @@ describe("meditationLibrary", () => {
     expect(template.source).toBe("https://example.com/moon-breath.mp3");
   });
 
-  it("normalizes API wellness content into meditation templates and route params", () => {
+  it("normalizes detailed wellness content into meditation templates and route params", () => {
     const template = mapMeditationTemplate(
       {
         id: 1,
@@ -40,11 +40,32 @@ describe("meditationLibrary", () => {
         category: "Relaxation",
         duration: "2.5 min",
         image: "https://example.com/relaxing.png",
+        audio: "https://example.com/relaxing.mp3",
+        description: "A gentle practice to release tension and find inner calm.",
+        longDescription:
+          "This practice uses a Sattva-forward approach to settle mental noise, soften muscular holding, and anchor awareness in the present moment.",
+        guidance:
+          "Focus on a slow inhale and a longer exhale. Let the body feel supported.",
         rating: 4.9,
         reviews: 128,
         tags: ["Calm", "Vata Balancing", "Vedic Wisdom", "Visualization"],
         level: "Beginner",
         dosha: "Vata",
+        instructor: {
+          name: "Dr. Amara Sethi",
+          role: "Lead Research & Vedic Scholar",
+          bio: "Dr. Sethi is a lead research scholar specializing in Vedic psychology and contemplative neuroscience.",
+          image: "https://example.com/instructor.png",
+        },
+        benefits: [
+          { id: 1, title: "Cognitive Clarity", text: "Settles mental noise." },
+        ],
+        scientificSynthesis: {
+          title: "Structural Resilience & Network Stability",
+          text: "Mindfulness practice is associated with stronger attentional control.",
+          source:
+            "Massachusetts General Hospital. (2025). Mindfulness meditation and network neuroscience review.",
+        },
       },
       0
     );
@@ -52,9 +73,17 @@ describe("meditationLibrary", () => {
     const params = buildMeditationRouteParams(template);
     const hydrated = hydrateMeditationTemplate(params, template);
 
-    expect(template.id).toBe("relaxing-meditation");
+    expect(template.id).toBe("1");
     expect(template.slug).toBe("relaxing-meditation");
     expect(template.durationLabel).toBe("2.5 min");
+    expect(template.source).toBe("https://example.com/relaxing.mp3");
+    expect(template.longDescription).toContain("Sattva-forward");
+    expect(template.guidance).toContain("slow inhale");
+    expect(template.instructor?.name).toBe("Dr. Amara Sethi");
+    expect(template.benefits).toHaveLength(1);
+    expect(template.scientificSynthesis?.title).toBe(
+      "Structural Resilience & Network Stability"
+    );
     expect(template.tag).toBe("calm");
     expect(template.tags).toContain("calm");
     expect(template.tags).toContain("vata-balancing");
@@ -62,8 +91,9 @@ describe("meditationLibrary", () => {
     expect(template.dosha).toBe("Vata");
     expect(template.rating).toBe(4.9);
     expect(template.reviews).toBe(128);
-    expect(params.meditationId).toBe("relaxing-meditation");
+    expect(params.meditationId).toBe("1");
     expect(params.meditationImage).toBe("https://example.com/relaxing.png");
+    expect(params.meditationSource).toBe("https://example.com/relaxing.mp3");
     expect(hydrated.title).toBe("Relaxing Meditation");
     expect(hydrated.durationLabel).toBe("2.5 min");
   });

--- a/features/self-care/utils/meditationLibrary.ts
+++ b/features/self-care/utils/meditationLibrary.ts
@@ -1,6 +1,8 @@
 import type { ImageSourcePropType } from "react-native";
 
 const FALLBACK_IMAGE = require("../../../assets/images/mt.jpg");
+const DEFAULT_MEDITATION_DESCRIPTION =
+  "A quiet cadence for the body and the part of the mind that listens.";
 
 const MEDITATION_TAG_PRIORITY = [
   "breath",
@@ -10,6 +12,23 @@ const MEDITATION_TAG_PRIORITY = [
   "release",
   "beginner",
 ] as const;
+
+type RouteValue = string | string[] | undefined;
+
+export type MeditationRouteParams = {
+  meditationId?: RouteValue;
+  meditationTitle?: RouteValue;
+  meditationDescription?: RouteValue;
+  meditationDurationLabel?: RouteValue;
+  meditationImage?: RouteValue;
+  meditationTags?: RouteValue;
+  meditationCategory?: RouteValue;
+  meditationRating?: RouteValue;
+  meditationReviews?: RouteValue;
+  meditationLevel?: RouteValue;
+  meditationDosha?: RouteValue;
+  meditationSource?: RouteValue;
+};
 
 export type MeditationTemplate = {
   id: string;
@@ -22,18 +41,31 @@ export type MeditationTemplate = {
   source?: string | null;
   isLocked: boolean;
   category?: string;
+  slug?: string;
+  rating?: number;
+  reviews?: number;
+  level?: string;
+  dosha?: string;
+  modality?: string;
 };
 
 export type RawMeditationTemplate = {
   id?: number | string;
+  slug?: string;
   title?: string;
   description?: string;
-  image?: string | null;
+  image?: string | ImageSourcePropType | null;
   source?: string | null;
   category?: string;
   duration?: number | string;
   isLocked?: boolean;
   is_locked?: boolean;
+  tags?: string[];
+  rating?: number;
+  reviews?: number;
+  level?: string;
+  dosha?: string;
+  modality?: string;
 };
 
 const titleCase = (value: string) =>
@@ -42,6 +74,42 @@ const titleCase = (value: string) =>
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
+
+const firstRouteValue = (value?: RouteValue) =>
+  Array.isArray(value) ? value[0] : value;
+
+const parseOptionalNumber = (value?: RouteValue) => {
+  const rawValue = firstRouteValue(value)?.trim();
+  if (!rawValue) return undefined;
+
+  const parsed = Number(rawValue);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const isGenericMetaValue = (value?: string | null) => {
+  if (!value) return true;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "all" || normalized === "all levels";
+};
+
+const normalizeTagSource = (value?: string | null) => {
+  if (!value || isGenericMetaValue(value)) return null;
+  return normalizeMeditationTag(value);
+};
+
+const formatDurationLabel = (duration: number | string | undefined) => {
+  if (typeof duration === "number" && Number.isFinite(duration)) {
+    return `${duration} min`;
+  }
+
+  if (typeof duration === "string") {
+    const trimmed = duration.trim();
+    if (!trimmed) return "5 min";
+    return trimmed.includes("min") ? trimmed : `${trimmed} min`;
+  }
+
+  return "5 min";
+};
 
 export const normalizeMeditationTag = (value: string) =>
   value
@@ -64,12 +132,76 @@ const tagMatchers: { pattern: RegExp; tag: string }[] = [
   { pattern: /\b(beginner|starter|intro)\b/i, tag: "beginner" },
 ];
 
+const resolveMeditationImageSource = (
+  image?: string | ImageSourcePropType | null
+): ImageSourcePropType => {
+  if (!image) return FALLBACK_IMAGE;
+  if (typeof image === "string") return { uri: image };
+  return image;
+};
+
+const extractMeditationImageUri = (image?: ImageSourcePropType | string | null) => {
+  if (!image) return undefined;
+  if (typeof image === "string") return image;
+  if (Array.isArray(image)) {
+    const first = image[0];
+    return extractMeditationImageUri(first ?? null);
+  }
+  if (typeof image === "object") {
+    const maybeImage = image as { uri?: unknown };
+    if (typeof maybeImage.uri === "string" && maybeImage.uri.trim()) {
+      return maybeImage.uri.trim();
+    }
+  }
+
+  return undefined;
+};
+
+const buildMeditationDescription = (
+  item: RawMeditationTemplate,
+  title: string,
+  tags: string[]
+) => {
+  if (typeof item.description === "string" && item.description.trim()) {
+    return item.description.trim();
+  }
+
+  const descriptors = [
+    item.category?.trim() ? formatMeditationTagLabel(item.category.trim()) : null,
+    item.level?.trim() && !isGenericMetaValue(item.level)
+      ? formatMeditationTagLabel(item.level.trim())
+      : null,
+    item.dosha?.trim() && !isGenericMetaValue(item.dosha)
+      ? formatMeditationTagLabel(item.dosha.trim())
+      : null,
+  ].filter(Boolean) as string[];
+
+  if (descriptors.length > 0) {
+    return `A quiet session shaped for ${descriptors.join(", ")}.`;
+  }
+
+  const primaryTag = tags[0];
+  if (primaryTag) {
+    return `A quiet session centered on ${formatMeditationTagLabel(primaryTag)}.`;
+  }
+
+  return title ? `A quiet session centered on ${title}.` : DEFAULT_MEDITATION_DESCRIPTION;
+};
+
 export const deriveMeditationTags = (
   item: RawMeditationTemplate,
   title: string,
   description: string
 ) => {
-  const sourceText = [title, description, item.category ?? ""]
+  const sourceTags = Array.isArray(item.tags) ? item.tags : [];
+  const sourceText = [
+    title,
+    description,
+    item.category ?? "",
+    item.level ?? "",
+    item.dosha ?? "",
+    ...sourceTags,
+  ]
     .join(" ")
     .toLowerCase();
 
@@ -77,12 +209,21 @@ export const deriveMeditationTags = (
     .filter(({ pattern }) => pattern.test(sourceText))
     .map(({ tag }) => tag);
 
-  const fallback = normalizeMeditationTag(item.category ?? "");
-  const tags = derived.length ? derived : [fallback || "calm"];
+  const metadataTags = [item.category, item.level, item.dosha]
+    .map(normalizeTagSource)
+    .filter((tag): tag is string => Boolean(tag));
 
-  return Array.from(
-    new Set(tags.map((tag) => normalizeMeditationTag(tag)).filter(Boolean))
-  );
+  const combined = [
+    ...sourceTags
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0)
+      .filter((tag) => !isGenericMetaValue(tag))
+      .map(normalizeMeditationTag),
+    ...metadataTags,
+    ...derived,
+  ];
+
+  return Array.from(new Set(combined.filter(Boolean)));
 };
 
 export const sortMeditationTags = (tags: string[]) => {
@@ -106,30 +247,30 @@ export const mapMeditationTemplate = (
   index: number
 ): MeditationTemplate => {
   const title = item.title?.trim() || `Meditation ${index + 1}`;
-  const description =
-    item.description?.trim() ||
-    "A quiet cadence for the body and the part of the mind that listens.";
-  const tags = sortMeditationTags(deriveMeditationTags(item, title, description));
-  const durationValue =
-    typeof item.duration === "number"
-      ? `${item.duration} min`
-      : typeof item.duration === "string" && item.duration.trim()
-        ? item.duration.includes("min")
-          ? item.duration.trim()
-          : `${item.duration.trim()} min`
-        : "5 min";
+  const tags = sortMeditationTags(
+    deriveMeditationTags(item, title, item.description?.trim() || "")
+  );
+  const description = buildMeditationDescription(item, title, tags);
+  const durationValue = formatDurationLabel(item.duration);
+  const idValue = item.slug?.trim() || item.id;
 
   return {
-    id: String(item.id ?? `${title}-${index}`),
+    id: String(idValue ?? `${title}-${index}`),
+    slug: item.slug?.trim() || undefined,
     title,
     description,
     tag: tags[0] ?? "calm",
     tags,
     durationLabel: durationValue,
-    image: item.image ? { uri: item.image } : FALLBACK_IMAGE,
+    image: resolveMeditationImageSource(item.image),
     source: item.source ?? null,
     isLocked: Boolean(item.isLocked ?? item.is_locked),
     category: item.category?.trim() || tags[0] || "calm",
+    rating: typeof item.rating === "number" ? item.rating : undefined,
+    reviews: typeof item.reviews === "number" ? item.reviews : undefined,
+    level: item.level?.trim() || undefined,
+    dosha: item.dosha?.trim() || undefined,
+    modality: item.modality?.trim() || undefined,
   };
 };
 
@@ -151,6 +292,100 @@ export const filterMeditationTemplates = (
 ) => {
   if (selectedTag === "all") return templates;
   return templates.filter((template) => template.tags.includes(selectedTag));
+};
+
+export const buildMeditationRouteParams = (
+  template: MeditationTemplate
+): MeditationRouteParams => ({
+  meditationId: template.slug ?? template.id,
+  meditationTitle: template.title,
+  meditationDescription: template.description,
+  meditationDurationLabel: template.durationLabel,
+  meditationImage: extractMeditationImageUri(template.image),
+  meditationTags: template.tags.length > 0 ? template.tags.join("|") : undefined,
+  meditationCategory: template.category ?? undefined,
+  meditationRating:
+    typeof template.rating === "number" ? String(template.rating) : undefined,
+  meditationReviews:
+    typeof template.reviews === "number" ? String(template.reviews) : undefined,
+  meditationLevel: template.level ?? undefined,
+  meditationDosha: template.dosha ?? undefined,
+  meditationSource: template.source ?? undefined,
+});
+
+export const hydrateMeditationTemplate = (
+  params: MeditationRouteParams,
+  fallback?: MeditationTemplate | null
+): MeditationTemplate => {
+  const fallbackTemplate = fallback ?? fallbackMeditationTemplates[0];
+  const title = firstRouteValue(params.meditationTitle)?.trim() ||
+    fallbackTemplate.title;
+  const routeTags = firstRouteValue(params.meditationTags)
+    ?.split("|")
+    .map((tag) => tag.trim())
+    .filter(Boolean) ?? [];
+  const fallbackTags = fallbackTemplate.tags ?? [];
+  const tags = sortMeditationTags(
+    routeTags.length > 0 ? routeTags : fallbackTags
+  );
+  const hasExplicitMetadata = Boolean(
+    firstRouteValue(params.meditationTitle) ||
+      firstRouteValue(params.meditationDescription) ||
+      firstRouteValue(params.meditationTags) ||
+      firstRouteValue(params.meditationCategory) ||
+      firstRouteValue(params.meditationLevel) ||
+      firstRouteValue(params.meditationDosha) ||
+      firstRouteValue(params.meditationDurationLabel) ||
+      firstRouteValue(params.meditationImage) ||
+      firstRouteValue(params.meditationSource) ||
+      firstRouteValue(params.meditationRating) ||
+      firstRouteValue(params.meditationReviews)
+  );
+  const description =
+    firstRouteValue(params.meditationDescription)?.trim() ||
+    (hasExplicitMetadata
+      ? buildMeditationDescription(
+          {
+            category: firstRouteValue(params.meditationCategory)?.trim(),
+            level: firstRouteValue(params.meditationLevel)?.trim(),
+            dosha: firstRouteValue(params.meditationDosha)?.trim(),
+          },
+          title,
+          tags
+        )
+      : fallbackTemplate.description);
+  const durationLabel =
+    firstRouteValue(params.meditationDurationLabel)?.trim() ||
+    fallbackTemplate.durationLabel;
+
+  return {
+    ...fallbackTemplate,
+    id: firstRouteValue(params.meditationId)?.trim() || fallbackTemplate.id,
+    slug: firstRouteValue(params.meditationId)?.trim() || fallbackTemplate.slug,
+    title,
+    description,
+    tag: tags[0] ?? fallbackTemplate.tag ?? "calm",
+    tags: tags.length > 0 ? tags : fallbackTags,
+    durationLabel,
+    image: resolveMeditationImageSource(
+      firstRouteValue(params.meditationImage) || fallbackTemplate.image
+    ),
+    source: firstRouteValue(params.meditationSource) ?? fallbackTemplate.source ?? null,
+    category:
+      firstRouteValue(params.meditationCategory)?.trim() ||
+      fallbackTemplate.category ||
+      tags[0] ||
+      "calm",
+    rating: parseOptionalNumber(params.meditationRating) ?? fallbackTemplate.rating,
+    reviews: parseOptionalNumber(params.meditationReviews) ?? fallbackTemplate.reviews,
+    level:
+      firstRouteValue(params.meditationLevel)?.trim() ||
+      fallbackTemplate.level,
+    dosha:
+      firstRouteValue(params.meditationDosha)?.trim() ||
+      fallbackTemplate.dosha,
+    modality: fallbackTemplate.modality ?? "meditation",
+  };
 };
 
 export const fallbackMeditationTemplates: MeditationTemplate[] = [

--- a/features/self-care/utils/meditationLibrary.ts
+++ b/features/self-care/utils/meditationLibrary.ts
@@ -1,5 +1,11 @@
 import type { ImageSourcePropType } from "react-native";
 
+import type {
+  WellnessContentBenefit,
+  WellnessContentInstructor,
+  WellnessContentScientificSynthesis,
+} from "@/features/self-care/types/selfCareTypes";
+
 const FALLBACK_IMAGE = require("../../../assets/images/mt.jpg");
 const DEFAULT_MEDITATION_DESCRIPTION =
   "A quiet cadence for the body and the part of the mind that listens.";
@@ -47,6 +53,12 @@ export type MeditationTemplate = {
   level?: string;
   dosha?: string;
   modality?: string;
+  longDescription?: string;
+  guidance?: string;
+  date?: string;
+  instructor?: WellnessContentInstructor;
+  benefits?: WellnessContentBenefit[];
+  scientificSynthesis?: WellnessContentScientificSynthesis;
 };
 
 export type RawMeditationTemplate = {
@@ -54,8 +66,12 @@ export type RawMeditationTemplate = {
   slug?: string;
   title?: string;
   description?: string;
+  longDescription?: string;
+  guidance?: string;
+  date?: string;
   image?: string | ImageSourcePropType | null;
   source?: string | null;
+  audio?: string | null;
   category?: string;
   duration?: number | string;
   isLocked?: boolean;
@@ -66,6 +82,9 @@ export type RawMeditationTemplate = {
   level?: string;
   dosha?: string;
   modality?: string;
+  instructor?: WellnessContentInstructor;
+  benefits?: WellnessContentBenefit[];
+  scientificSynthesis?: WellnessContentScientificSynthesis;
 };
 
 const titleCase = (value: string) =>
@@ -155,6 +174,69 @@ const extractMeditationImageUri = (image?: ImageSourcePropType | string | null) 
   }
 
   return undefined;
+};
+
+const normalizeInstructor = (
+  instructor?: WellnessContentInstructor
+): WellnessContentInstructor | undefined => {
+  if (!instructor) return undefined;
+
+  const name = instructor.name.trim();
+  const role = instructor.role.trim();
+  const bio = instructor.bio.trim();
+  const image = instructor.image.trim();
+
+  if (!name && !role && !bio && !image) {
+    return undefined;
+  }
+
+  return {
+    name: name || "Instructor",
+    role,
+    bio,
+    image,
+  };
+};
+
+const normalizeBenefits = (
+  benefits?: WellnessContentBenefit[]
+): WellnessContentBenefit[] | undefined => {
+  if (!Array.isArray(benefits)) return undefined;
+
+  const normalized = benefits
+    .map((benefit) => ({
+      id: benefit.id,
+      title: benefit.title.trim(),
+      text: benefit.text.trim(),
+    }))
+    .filter(
+      (benefit) =>
+        Boolean(benefit.title) || Boolean(benefit.text) || Number.isFinite(benefit.id)
+    );
+
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+const normalizeScientificSynthesis = (
+  scientificSynthesis?: WellnessContentScientificSynthesis
+):
+  | WellnessContentScientificSynthesis
+  | undefined => {
+  if (!scientificSynthesis) return undefined;
+
+  const title = scientificSynthesis.title.trim();
+  const text = scientificSynthesis.text.trim();
+  const source = scientificSynthesis.source.trim();
+
+  if (!title && !text && !source) {
+    return undefined;
+  }
+
+  return {
+    title: title || "Scientific synthesis",
+    text,
+    source,
+  };
 };
 
 const buildMeditationDescription = (
@@ -250,9 +332,14 @@ export const mapMeditationTemplate = (
   const tags = sortMeditationTags(
     deriveMeditationTags(item, title, item.description?.trim() || "")
   );
-  const description = buildMeditationDescription(item, title, tags);
+  const description =
+    item.description?.trim() ||
+    item.longDescription?.trim() ||
+    buildMeditationDescription(item, title, tags);
+  const longDescription = item.longDescription?.trim() || undefined;
   const durationValue = formatDurationLabel(item.duration);
-  const idValue = item.slug?.trim() || item.id;
+  const idValue = item.id ?? item.slug;
+  const source = item.audio?.trim() || item.source?.trim() || null;
 
   return {
     id: String(idValue ?? `${title}-${index}`),
@@ -263,7 +350,7 @@ export const mapMeditationTemplate = (
     tags,
     durationLabel: durationValue,
     image: resolveMeditationImageSource(item.image),
-    source: item.source ?? null,
+    source,
     isLocked: Boolean(item.isLocked ?? item.is_locked),
     category: item.category?.trim() || tags[0] || "calm",
     rating: typeof item.rating === "number" ? item.rating : undefined,
@@ -271,6 +358,12 @@ export const mapMeditationTemplate = (
     level: item.level?.trim() || undefined,
     dosha: item.dosha?.trim() || undefined,
     modality: item.modality?.trim() || undefined,
+    longDescription,
+    guidance: item.guidance?.trim() || undefined,
+    date: item.date?.trim() || undefined,
+    instructor: normalizeInstructor(item.instructor),
+    benefits: normalizeBenefits(item.benefits),
+    scientificSynthesis: normalizeScientificSynthesis(item.scientificSynthesis),
   };
 };
 
@@ -297,7 +390,7 @@ export const filterMeditationTemplates = (
 export const buildMeditationRouteParams = (
   template: MeditationTemplate
 ): MeditationRouteParams => ({
-  meditationId: template.slug ?? template.id,
+  meditationId: template.id,
   meditationTitle: template.title,
   meditationDescription: template.description,
   meditationDurationLabel: template.durationLabel,

--- a/features/self-care/utils/meditationPlayback.ts
+++ b/features/self-care/utils/meditationPlayback.ts
@@ -4,8 +4,13 @@ const DEFAULT_MEDITATION_AUDIO = require("../../../assets/audio/deep_sleep_guide
 const DEFAULT_MEDITATION_COVER = require("../../../assets/images/mt.jpg");
 
 export const resolveMeditationPlaybackSource = (
-  meditationId?: string | null
+  meditationId?: string | null,
+  meditationSource?: string | null
 ) => {
+  if (meditationSource) {
+    return { uri: meditationSource };
+  }
+
   switch (meditationId) {
     default:
       return DEFAULT_MEDITATION_AUDIO;
@@ -40,4 +45,3 @@ export const seekMillis = (
   const nextPosition = currentPosition + delta;
   return Math.max(0, Math.min(nextPosition, Math.max(durationMillis - 500, 0)));
 };
-


### PR DESCRIPTION
## What changed
- Replaced the meditation library screen's local mock data with `GET /api/v1/wellness-content/?modality=meditation`.
- Added a shared wellness-content response type and service method for meditation content.
- Normalized API records into the existing meditation card/detail/player shape, including tags, duration labels, image URLs, and route params.
- Updated the detail and player screens to hydrate from the route payload so API-backed items render correctly end-to-end.
- Added tests for the service, mapper, screen flow, and route payload hydration.

## Why
- The meditation list should come from the backend wellness-content API instead of the static local recommendation set.
- The detail and player screens still need the same content metadata once the user taps an item from the API-backed list.

## Validation
- `npx jest --runInBand features/self-care/services/__tests__/selfCareService.test.ts features/self-care/utils/__tests__/meditationLibrary.test.ts features/self-care/screens/__tests__/MeditationScreen.test.tsx features/self-care/screens/__tests__/MeditationDetailScreen.test.tsx features/self-care/screens/__tests__/MeditationPlayerScreen.test.tsx`
- `npx eslint config/apiConfig.ts features/self-care/services/selfCareService.ts features/self-care/services/__tests__/selfCareService.test.ts features/self-care/types/selfCareTypes.ts features/self-care/utils/meditationLibrary.ts features/self-care/utils/__tests__/meditationLibrary.test.ts features/self-care/screens/MeditationScreen.tsx features/self-care/screens/MeditationDetailScreen.tsx features/self-care/screens/MeditationPlayerScreen.tsx features/self-care/screens/__tests__/MeditationScreen.test.tsx features/self-care/screens/__tests__/MeditationDetailScreen.test.tsx features/self-care/screens/__tests__/MeditationPlayerScreen.test.tsx`
