### PR TITLE
[codex] sync body vitals panels and auth session state

### DIFF
--- a/app/(auth)/(tabs)/settings.tsx
+++ b/app/(auth)/(tabs)/settings.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useMemo, useState } from "react";
 import { router } from "expo-router";
 import * as Location from "expo-location";
 import { StatusBar } from "expo-status-bar";
-import { ScrollView, StyleSheet, View } from "react-native";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import ThemeContext from "@/contexts/ThemeContext";
@@ -42,12 +42,20 @@ const SVA_SOCIAL_WEB_URL = "https://instagram.com/sva_app";
 
 export default function SettingsScreen() {
   const { toggleTheme, newTheme } = useContext(ThemeContext);
-  const { onLogout, userProfile } = useAuth();
+  const {
+    onLogout,
+    userProfile,
+    resetToPublic,
+    authSessionTestMode,
+    setAuthSessionTestMode,
+  } = useAuth();
   const insets = useSafeAreaInsets();
 
   const [toggleState, setToggleState] = useState<ToggleState>(
     INITIAL_TOGGLE_STATE
   );
+  const [authResetting, setAuthResetting] = useState(false);
+  const [authModeSaving, setAuthModeSaving] = useState(false);
   const [loc, setLoc] = useState<Location.LocationObject | null>(null);
 
   const [showReportBugModal, setShowReportBugModal] = useState(false);
@@ -79,6 +87,9 @@ export default function SettingsScreen() {
     const handle = userProfile?.username?.trim();
     return `#${handle || "321be4"} glow active`;
   }, [userProfile]);
+
+  const showAuthTestControls = __DEV__;
+  const authTestTimeoutLabel = authSessionTestMode ? "15 min" : "15 days";
 
   const membershipLabel = useMemo(
     () => getMembershipLabel(userProfile),
@@ -125,6 +136,28 @@ export default function SettingsScreen() {
   const onLogoutClick = async () => {
     if (onLogout) {
       await onLogout();
+    }
+  };
+
+  const onResetAuthClick = async () => {
+    if (!resetToPublic || authResetting) return;
+
+    try {
+      setAuthResetting(true);
+      await resetToPublic();
+    } finally {
+      setAuthResetting(false);
+    }
+  };
+
+  const onAuthTestModeToggle = async (next: boolean) => {
+    if (!setAuthSessionTestMode || authModeSaving) return;
+
+    try {
+      setAuthModeSaving(true);
+      await setAuthSessionTestMode(next);
+    } finally {
+      setAuthModeSaving(false);
     }
   };
 
@@ -279,6 +312,45 @@ export default function SettingsScreen() {
               })}
             </SettingsSectionCard>
           ))}
+
+          {showAuthTestControls ? (
+            <SettingsSectionCard
+              title="Developer"
+              icon="bug-outline"
+              style={styles.sectionCard}
+            >
+              <SettingsRow
+                icon="timer-outline"
+                label="Auth test mode"
+                style={styles.rowSpacing}
+                rightSlot={
+                  <View style={styles.devRowRightSlot}>
+                    <Text
+                      style={[
+                        styles.devRowValue,
+                        { color: newTheme.textSecondary },
+                      ]}
+                    >
+                      {authTestTimeoutLabel}
+                    </Text>
+                    <SettingsToggle
+                      value={Boolean(authSessionTestMode)}
+                      onValueChange={(next) => void onAuthTestModeToggle(next)}
+                      disabled={authModeSaving}
+                    />
+                  </View>
+                }
+              />
+
+              <SettingsRow
+                icon="refresh-circle-outline"
+                label={authResetting ? "Resetting app..." : "Reset auth session"}
+                danger
+                showChevron
+                onPress={() => void onResetAuthClick()}
+              />
+            </SettingsSectionCard>
+          ) : null}
         </View>
 
         <SettingsFooter />
@@ -354,5 +426,15 @@ const styles = StyleSheet.create({
   },
   rowSpacing: {
     marginBottom: 4,
+  },
+  devRowRightSlot: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  devRowValue: {
+    fontSize: 12,
+    letterSpacing: 0.6,
+    textTransform: "uppercase",
   },
 });

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,11 +1,11 @@
 // app/index.tsx
 import React, { useEffect, useState } from "react";
 import { Redirect } from "expo-router";
+import { ROUTES } from "@/constants/routes";
 import * as SecureStore from "expo-secure-store";
 import { StoreKey } from "@/constants/Constant";
-import { ROUTES } from "@/constants/routes";
+import { getFreshAuthTokenOrClearSession } from "@/services/authSessionService";
 
-const TOKEN_KEY = StoreKey.TOKEN_KEY;
 const ONBOARDING_DONE_KEY = StoreKey.ONBOARDING_DONE_KEY;
 
 type Href =
@@ -18,7 +18,23 @@ export default function Index() {
 
   useEffect(() => {
     (async () => {
-      const token = await SecureStore.getItemAsync(TOKEN_KEY);
+      /*
+       * TEMP: uncomment while working on onboarding.
+       * This forces a clean app start by clearing auth/session state before
+       * the initial route decision.
+       *
+       * await Promise.all([
+       *   SecureStore.deleteItemAsync(StoreKey.TOKEN_KEY),
+       *   SecureStore.deleteItemAsync(StoreKey.REFRESH_TOKEN),
+       *   SecureStore.deleteItemAsync(StoreKey.ONBOARDING_DONE_KEY),
+       *   SecureStore.deleteItemAsync(StoreKey.LAST_ACTIVE_KEY),
+       * ]);
+       *
+       * setHref(ROUTES.PUBLIC.LANDING);
+       * return;
+       */
+
+      const token = await getFreshAuthTokenOrClearSession();
 
       // ✅ No token => always show Landing first
       if (!token) {

--- a/constants/Constant.ts
+++ b/constants/Constant.ts
@@ -3,7 +3,9 @@ export const StoreKey = {
   USER_KEY: "user",
   REFRESH_TOKEN: "refresh-token",
   USER_PROFILE_KEY: "user-profile",
+  BODY_VITALS_CONTEXT_KEY: "body-vitals-context",
   LAST_ACTIVE_KEY: "last-active-ts",
+  AUTH_SESSION_TEST_MODE_KEY: "auth-session-test-mode",
   WELCOME_SEEN_KEY: "welcome-seen",
   ONBOARDING_DONE_KEY: "onboarding-done",
 };

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -6,15 +6,15 @@ import {
   useRef,
 } from "react";
 import { useContext, useState } from "react";
+import { AppState } from "react-native";
 import { router, useSegments } from "expo-router";
 import * as SecureStore from "expo-secure-store";
 import axios from "axios";
 
 import { StoreKey } from "@/constants/Constant";
+import { API_ENDPOINTS } from "@/config/apiConfig";
 import { ROUTES } from "@/constants/routes";
-import {
-  normalizeUserProfile,
-} from "@/features/auth/utils/userEntitlements";
+import { normalizeUserProfile } from "@/features/auth/utils/userEntitlements";
 import type { UserProfile } from "@/features/auth/types/userProfile";
 import {
   login,
@@ -24,32 +24,37 @@ import {
   saveUpdateUser,
 } from "@/features/auth/services/loginService";
 import { setStoredUser, User, getStoredUser } from "@/services/storageService";
-import { storageKey } from "@/services/remiderStorageService";
+import {
+  clearAuthSession,
+  getAuthSessionTestModeEnabled,
+  getFreshAuthTokenOrClearSession,
+  setAuthSessionTestModeEnabled,
+  touchAuthSessionActivity,
+} from "@/services/authSessionService";
+import { syncStoredBodyVitalsContext } from "@/features/self-care/services/bodyVitalsStorage";
 
 export async function clearAuthAndOnboarding() {
-  await SecureStore.deleteItemAsync(StoreKey.TOKEN_KEY);
-  await SecureStore.deleteItemAsync(StoreKey.REFRESH_TOKEN);
-  await SecureStore.deleteItemAsync(StoreKey.ONBOARDING_DONE_KEY);
+  await clearAuthSession();
 }
-
-const resetApp = async () => {
-  await clearAuthAndOnboarding();
-  router.replace(ROUTES.PUBLIC.LANDING);
-};
 
 // Cache Token Key
 const TOKEN_KEY = StoreKey.TOKEN_KEY;
-const USER_KEY = StoreKey.USER_KEY;
 const REFRESH_TOKEN = StoreKey.REFRESH_TOKEN;
-const USER_PROFILE_KEY = StoreKey.USER_PROFILE_KEY;
-const LAST_ACTIVE_KEY = StoreKey.LAST_ACTIVE_KEY;
-const WELCOME_SEEN_KEY = StoreKey.WELCOME_SEEN_KEY;
-const ONBOARDING_DONE_KEY = StoreKey.ONBOARDING_DONE_KEY;
+const AUTH_ENDPOINTS = [
+  API_ENDPOINTS.login,
+  API_ENDPOINTS.register,
+  API_ENDPOINTS.logout,
+  API_ENDPOINTS.getOtp,
+  API_ENDPOINTS.verifyOtp,
+  API_ENDPOINTS.setPassword,
+  API_ENDPOINTS.forgotPassword,
+  API_ENDPOINTS.changePassword,
+];
 
-// Refresh intervals & expiry
-const REFRESH_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
-const AUTO_LOGOUT_DAYS = 15;
-const AUTO_LOGOUT_MS = AUTO_LOGOUT_DAYS * 24 * 60 * 60 * 1000;
+function isAuthEndpoint(url?: string) {
+  if (!url) return false;
+  return AUTH_ENDPOINTS.some((endpoint) => url.startsWith(endpoint));
+}
 
 interface AuthProps {
   authState?: { token: string | null; authenticated: boolean | null };
@@ -70,7 +75,8 @@ interface AuthProps {
   resetToPublic?: () => Promise<void>;
   markOnboardingDone?: () => Promise<void>;
   onboardingDone?: boolean | null;
-  user?: User;
+  authSessionTestMode?: boolean;
+  setAuthSessionTestMode?: (enabled: boolean) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthProps>({});
@@ -88,14 +94,16 @@ function useProtectedRoute(
   onboardingDone: boolean | null
 ) {
   const segments = useSegments() as string[];
+  const hasSegments = segments.length > 0;
+  const segmentsKey = segments.join("/");
+  const root = segments[0];
+  const child = segments[1];
 
   useEffect(() => {
     if (authState.authenticated === null) return;
-    if (!segments?.length) return;
+    if (!hasSegments) return;
 
     const isAuthed = authState.authenticated === true;
-    const root = segments[0];
-    const child = segments[1];
 
     if (isAuthed && onboardingDone === null) return;
 
@@ -118,16 +126,10 @@ function useProtectedRoute(
       return; // ✅ allow any /(auth) route
     }
     if (isAuthed && onboardingDone === null) return;
-  }, [authState.authenticated, onboardingDone, segments.join("/")]);
+  }, [authState.authenticated, onboardingDone, hasSegments, root, child, segmentsKey]);
 }
 
 export default function AuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<User>();
-  const [loggedInUser, setLoggedInUser] = useState<{
-    email: string | null;
-    username: string | null;
-  } | null>();
-
   const [authState, setAuthState] = useState<{
     token: string | null;
     authenticated: boolean | null;
@@ -135,6 +137,15 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
 
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [onboardingDone, setOnboardingDone] = useState<boolean | null>(null);
+  const [authSessionTestMode, setAuthSessionTestModeState] =
+    useState<boolean>(false);
+
+  const sessionClearInProgressRef = useRef(false);
+  const authStateRef = useRef(authState);
+
+  useEffect(() => {
+    authStateRef.current = authState;
+  }, [authState]);
 
   useEffect(() => {
     (async () => {
@@ -153,10 +164,41 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     })();
   }, [authState.authenticated]);
 
-  // refs for refresh flow
-  const isRefreshingRef = useRef(false);
-  const refreshPromiseRef = useRef<Promise<string | null> | null>(null);
-  const refreshIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  useEffect(() => {
+    (async () => {
+      const enabled = await getAuthSessionTestModeEnabled();
+      setAuthSessionTestModeState(enabled);
+    })();
+  }, []);
+
+  const clearLocalSession = useCallback(async () => {
+    if (sessionClearInProgressRef.current) return;
+
+    sessionClearInProgressRef.current = true;
+
+    try {
+      await clearAuthSession();
+    } catch {
+      // Keep going: state must still be cleared locally.
+    } finally {
+      delete axios.defaults.headers.common["Authorization"];
+      setAuthState({ token: null, authenticated: false });
+      setUserProfile(null);
+      setOnboardingDone(null);
+      sessionClearInProgressRef.current = false;
+    }
+  }, []);
+
+  const setAuthSessionTestMode = useCallback(async (enabled: boolean) => {
+    await setAuthSessionTestModeEnabled(enabled);
+    setAuthSessionTestModeState(enabled);
+  }, []);
+
+  const resetToPublic = useCallback(async () => {
+    await clearLocalSession();
+
+    router.replace(ROUTES.PUBLIC.LANDING);
+  }, [clearLocalSession]);
 
   // Helper: set axios auth header + save token to secure store
   const applyAccessToken = async (accessToken: string | null) => {
@@ -164,68 +206,130 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       axios.defaults.headers.common["Authorization"] = `Bearer ${accessToken}`;
       setAuthState({ token: accessToken, authenticated: true });
       await SecureStore.setItemAsync(TOKEN_KEY, accessToken);
-      // update last active timestamp on token set
-      await SecureStore.setItemAsync(LAST_ACTIVE_KEY, String(Date.now()));
+      try {
+        await touchAuthSessionActivity();
+      } catch {
+        // A missing activity timestamp should not block login.
+      }
     } else {
       delete axios.defaults.headers.common["Authorization"];
       setAuthState({ token: null, authenticated: false });
     }
   };
 
-  // Helper: get refresh token from store
-  const getStoredRefreshToken = async () => {
-    return await SecureStore.getItemAsync(REFRESH_TOKEN);
-  };
-
   const loadUserFromStorage = useCallback(async (): Promise<User | null> => {
-    const cached = await getStoredUser();
-    // console.log(cached, "cached");
-    if (cached) {
-      // setUser(cached);
-      // setUserProfile(cached as any);
-    }
-    return cached;
+    return await getStoredUser();
   }, []);
 
   useEffect(() => {
     const loadToken = async () => {
-      resetApp();
       try {
-        const token = await SecureStore.getItemAsync(TOKEN_KEY);
-        const refresh = await SecureStore.getItemAsync(REFRESH_TOKEN);
-        const profileInfo = await SecureStore.getItemAsync(USER_PROFILE_KEY);
-
-        // ✅ Always load onboarding key too
+        const token = await getFreshAuthTokenOrClearSession();
         const ob = await SecureStore.getItemAsync(StoreKey.ONBOARDING_DONE_KEY);
 
         if (token) {
           axios.defaults.headers.common["Authorization"] = `Bearer ${token}`;
           setAuthState({ token, authenticated: true });
 
-          if (profileInfo) {
-            // Temporary entitlement seed: default to a free profile until the backend sends tier data consistently.
-            const cachedProfile = normalizeUserProfile(JSON.parse(profileInfo));
-            if (cachedProfile) setUserProfile(cachedProfile);
+          const cachedProfile = await getStoredUser();
+          if (cachedProfile) {
+            const normalizedProfile = normalizeUserProfile(cachedProfile);
+            setUserProfile(normalizedProfile);
+            await syncStoredBodyVitalsContext(normalizedProfile);
           }
-          // ✅ If key missing, decide a default (recommended: false)
           setOnboardingDone(ob === "true");
-        } else {
-          setAuthState({ token: null, authenticated: false });
+          return;
         }
-      } catch (e) {
+
+        delete axios.defaults.headers.common["Authorization"];
         setAuthState({ token: null, authenticated: false });
+        setUserProfile(null);
+        setOnboardingDone(null);
+      } catch {
+        delete axios.defaults.headers.common["Authorization"];
+        setAuthState({ token: null, authenticated: false });
+        setUserProfile(null);
+        setOnboardingDone(null);
       }
     };
 
-    loadToken();
+    void loadToken();
   }, []);
 
   useEffect(() => {
-    (async () => {
-      const v = await SecureStore.getItemAsync(StoreKey.ONBOARDING_DONE_KEY);
-      console.log("onboardingDone key: auth", v);
-    })();
-  }, []);
+    if (authState.authenticated !== true) return;
+
+    const checkSessionFreshness = async () => {
+      if (sessionClearInProgressRef.current) return;
+
+      const token = await getFreshAuthTokenOrClearSession();
+      if (!token) {
+        await resetToPublic();
+      }
+    };
+
+    void checkSessionFreshness();
+
+    const interval = setInterval(() => {
+      void checkSessionFreshness();
+    }, 60 * 1000);
+
+    const appStateSubscription = AppState.addEventListener("change", (nextState) => {
+      if (nextState === "active") {
+        void checkSessionFreshness();
+      }
+    });
+
+    return () => {
+      clearInterval(interval);
+      appStateSubscription.remove();
+    };
+  }, [authState.authenticated, resetToPublic]);
+
+  useEffect(() => {
+    const requestInterceptor = axios.interceptors.request.use(
+      async (config) => {
+        if (authStateRef.current.authenticated !== true) {
+          return config;
+        }
+
+        if (isAuthEndpoint(config.url)) {
+          return config;
+        }
+
+        const token = await getFreshAuthTokenOrClearSession();
+        if (!token) {
+          await resetToPublic();
+          return Promise.reject(new Error("Session expired"));
+        }
+
+        await touchAuthSessionActivity();
+        return config;
+      },
+      (error) => Promise.reject(error)
+    );
+
+    const responseInterceptor = axios.interceptors.response.use(
+      (response) => response,
+      async (error) => {
+        if (authStateRef.current.authenticated !== true) {
+          return Promise.reject(error);
+        }
+
+        const url = error?.config?.url as string | undefined;
+        if (error?.response?.status === 401 && !isAuthEndpoint(url)) {
+          await resetToPublic();
+        }
+
+        return Promise.reject(error);
+      }
+    );
+
+    return () => {
+      axios.interceptors.request.eject(requestInterceptor);
+      axios.interceptors.response.eject(responseInterceptor);
+    };
+  }, [resetToPublic]);
 
   const markOnboardingDone = useCallback(async () => {
     await SecureStore.setItemAsync(StoreKey.ONBOARDING_DONE_KEY, "true");
@@ -262,19 +366,12 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
           StoreKey.REFRESH_TOKEN,
           data.refresh ?? ""
         );
-        await SecureStore.setItemAsync(StoreKey.TOKEN_KEY, data.access);
+        await applyAccessToken(data.access);
         await SecureStore.setItemAsync(StoreKey.ONBOARDING_DONE_KEY, "false");
         setOnboardingDone(false);
-        await applyAccessToken(data.access); // sets axios header + authState + TOKEN_KEY
-        // await _fetchUserProfile(); // optional but recommended
-
-        axios.defaults.headers.common[
-          "Authorization"
-        ] = `Bearer ${data.access}`;
-        setAuthState({ token: data.access, authenticated: true });
         return result;
       }
-    } catch (e) {
+    } catch {
       return {
         success: false,
         error: true,
@@ -294,24 +391,10 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       const { success, message, data } = result;
 
       if (success && "email" in data) {
-        const { username, email, ...tokens } = data; // Destructuring user details separately
-        const userInfo = {
-          email: email,
-          username: username,
-        };
-        setAuthState({
-          token: tokens.access,
-          authenticated: true,
-        });
-        setLoggedInUser(userInfo);
+        const { access, refresh } = data;
+        await applyAccessToken(access);
 
-        axios.defaults.headers.common[
-          "Authorization"
-        ] = `Bearer ${tokens.access}`;
-
-        await SecureStore.setItemAsync(TOKEN_KEY, tokens.access);
-
-        await SecureStore.setItemAsync(REFRESH_TOKEN, tokens.refresh);
+        await SecureStore.setItemAsync(REFRESH_TOKEN, refresh);
 
         const ob = await SecureStore.getItemAsync(StoreKey.ONBOARDING_DONE_KEY);
         if (ob == null) {
@@ -320,8 +403,6 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
         }
 
         await _fetchUserProfile();
-
-        // await SecureStore.setItemAsync(USER_KEY, JSON.stringify(userInfo));
       } else {
         console.error("Login failed:", message);
       }
@@ -339,30 +420,21 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
         refresh: ref ?? "",
       };
 
-      const result = await logout(request);
+      await logout(request);
+    } catch {
+      // best effort remote logout; local session will still be cleared.
+    }
 
-      if (result.success && result.message) {
-        await clearAuthAndOnboarding();
-        await SecureStore.setItemAsync(TOKEN_KEY, "");
-        setOnboardingDone(null);
-        delete axios.defaults.headers.common["Authorization"];
-        await SecureStore.setItemAsync(USER_KEY, "");
-        await SecureStore.setItemAsync(REFRESH_TOKEN, "");
-        setLoggedInUser({ username: null, email: null });
-        setAuthState({
-          authenticated: false,
-          token: null,
-        });
-        setUserProfile(null);
-        router.replace(ROUTES.PUBLIC.LANDING);
-      }
-    } catch (e) {}
+    await resetToPublic();
   };
 
   // single place to update state + storage from server
-  const applyServerUser = useCallback(async (serverUser: User) => {
-    setUser(serverUser);
-    await setStoredUser(serverUser);
+  const applyServerUser = useCallback(async (serverUser: User | null) => {
+    const normalizedUser = normalizeUserProfile(serverUser);
+    setUserProfile(normalizedUser);
+    await setStoredUser(normalizedUser);
+    await syncStoredBodyVitalsContext(normalizedUser);
+    return normalizedUser;
   }, []);
 
   // public helpers
@@ -371,60 +443,16 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
   //   await setStoredUser(u);
   // }, []);
 
-  const resetToPublic = useCallback(async () => {
-    await SecureStore.deleteItemAsync(StoreKey.TOKEN_KEY);
-    await SecureStore.deleteItemAsync(StoreKey.REFRESH_TOKEN);
-    await SecureStore.deleteItemAsync(StoreKey.ONBOARDING_DONE_KEY);
-    setOnboardingDone(null);
-    delete axios.defaults.headers.common["Authorization"];
-
-    setAuthState({ token: null, authenticated: false });
-    setUserProfile(null);
-
-    router.replace(ROUTES.PUBLIC.LANDING);
-  }, []);
-
   const _fetchUserProfile = async () => {
     try {
-      const response = await getUserDetails(); // 👈 your backend endpoint
-      const { success, message, data } = response;
-      // console.log(response, "response auth context");
-      const { username, email, id, ...tokens } = data;
-      if (success && "email" in data) {
-        // console.log(response, "conimg response auth context 2222");
+      const response = await getUserDetails();
+      const { success, data } = response;
 
-        const {
-          username,
-          email,
-          first_name,
-          id,
-          last_name,
-          profile,
-          settings,
-          avatar,
-          notifications,
-          ...tokens
-        } = data;
-        const usr = normalizeUserProfile({
-          id: id,
-          avatar: data.avatar || null,
-          username: username,
-          email: email,
-          first_name: first_name,
-          last_name: last_name,
-          profile: profile,
-          settings: settings,
-          notifications: notifications,
-        });
-        if (usr) {
-          await applyServerUser(usr as any);
-        }
-        // const profileInfo = await SecureStore.getItem(USER_PROFILE_KEY);
-        await SecureStore.setItemAsync(USER_PROFILE_KEY, JSON.stringify(usr));
-        setUserProfile(usr);
-        return usr;
+      if (success && data) {
+        return await applyServerUser(data);
       }
-      // return response;
+
+      return null;
     } catch (e) {
       console.error("Failed to fetch user profile", e);
       return null;
@@ -437,33 +465,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
         const res = await saveUpdateUser(payload); // your API
         // if your API shape is { success, data: { user }, message }
         if (res?.success && res?.data) {
-          const { success, message, data } = res;
-          const {
-            id,
-            username,
-            email,
-            first_name,
-            last_name,
-            profile,
-            settings,
-            address,
-            notifications,
-            notification_preferences,
-          } = data;
-          const usr = normalizeUserProfile({
-            id: id,
-            username: username,
-            email: email,
-            avatar: profile?.avatar || null,
-            first_name: first_name,
-            last_name: last_name,
-            profile: profile,
-            settings: settings,
-            notifications: notifications,
-          });
-          await applyServerUser(usr as any); // keep app + storage in sync
-          await SecureStore.setItemAsync(USER_PROFILE_KEY, JSON.stringify(usr));
-          setUserProfile(usr);
+          await applyServerUser(res.data); // keep app + storage in sync
         }
         return res; // caller decides what to do
       } catch (err: any) {
@@ -483,6 +485,8 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     onLogout: _logout,
     userProfile,
     authState,
+    authSessionTestMode,
+    setAuthSessionTestMode,
     resetToPublic,
     getUserDetails: _fetchUserProfile,
     updateProfile: updateProfile,

--- a/docs/auth-session-logout.md
+++ b/docs/auth-session-logout.md
@@ -1,0 +1,94 @@
+# Auth Session Logout
+
+This document describes the current auth-session behavior in Nimbus:
+
+- Automatic logout after inactivity
+- A developer-only 15-minute test mode
+- A manual reset flow that clears local auth state and cached user data
+
+## Behavior Summary
+
+The app keeps track of the last authenticated activity timestamp and checks it against a timeout window.
+
+- Default timeout: `15 days`
+- Test timeout: `15 minutes`
+
+If the session has been inactive longer than the active timeout, the app clears local auth state and returns the user to the public landing screen.
+
+## What Counts As Activity
+
+The session timestamp is refreshed when:
+
+- A user logs in successfully
+- An authenticated API request is made
+- The app becomes active again and the session is re-checked
+
+This means the inactivity timer is based on real usage, not just app launches.
+
+## Where The Check Runs
+
+The session expiry check is enforced in a few places:
+
+- App bootstrap in [`app/index.tsx`](/Users/urvi/sva-workspace/nimbus/app/index.tsx)
+- Auth context startup in [`contexts/AuthContext.tsx`](/Users/urvi/sva-workspace/nimbus/contexts/AuthContext.tsx)
+- A repeating foreground timer while the user is authenticated
+- Axios request/response interceptors for authenticated API traffic
+
+If the token is expired or the last-active timestamp is outside the timeout window, the session is cleared immediately.
+
+## What Gets Cleared
+
+On logout or reset, the app removes:
+
+- Access token
+- Refresh token
+- Onboarding completion flag
+- Last active timestamp
+- Cached user profile
+- In-memory `Authorization` header on Axios
+
+The reset path returns the user to the public landing route.
+
+## Manual Logout Flow
+
+The normal logout action in Settings still calls the backend logout endpoint when possible.
+
+- The remote logout is best-effort
+- Local cleanup always runs
+- If the server call fails, the app still clears the local session
+
+## Developer Test Mode
+
+A developer-only auth test toggle is available in the Settings screen.
+
+- When disabled, the default `15 day` timeout is used
+- When enabled, the timeout becomes `15 minutes`
+- The toggle is stored locally so the test mode survives app reloads
+
+This is intended for manual verification of the auto-logout flow during development.
+
+## Manual Reset Flow
+
+The Settings screen also exposes a manual `Reset auth session` action in developer mode.
+
+That action calls the app reset flow directly and clears the same auth data listed above.
+
+Use this when you want to verify:
+
+- token removal
+- local cache cleanup
+- redirect back to landing
+
+## Relevant Files
+
+- [`services/authSessionService.ts`](/Users/urvi/sva-workspace/nimbus/services/authSessionService.ts)
+- [`contexts/AuthContext.tsx`](/Users/urvi/sva-workspace/nimbus/contexts/AuthContext.tsx)
+- [`app/index.tsx`](/Users/urvi/sva-workspace/nimbus/app/index.tsx)
+- [`app/(auth)/(tabs)/settings.tsx`](/Users/urvi/sva-workspace/nimbus/app/(auth)/(tabs)/settings.tsx)
+- [`constants/Constant.ts`](/Users/urvi/sva-workspace/nimbus/constants/Constant.ts)
+
+## Notes
+
+- The test switch is shown only in development builds.
+- The refresh token is still stored because the manual logout endpoint may use it, but there is no separate refresh-token renewal loop in the client.
+- If you want to verify expiry quickly, enable auth test mode and wait 15 minutes without authenticated activity.

--- a/features/auth/types/userProfile.ts
+++ b/features/auth/types/userProfile.ts
@@ -1,3 +1,5 @@
+import type { BodyVitalsContext } from "@/features/self-care/types/bodyVitals";
+
 export type UserSubscriptionTier = "free" | "plus";
 
 export type UserSubscription = {
@@ -27,5 +29,7 @@ export type UserProfile = {
   settings?: Record<string, unknown> | null;
   address?: Record<string, unknown> | null;
   notifications?: UserNotification[];
+  notification_preferences?: Record<string, unknown> | null;
+  vitals_context?: BodyVitalsContext | null;
   subscription?: UserSubscription | null;
 };

--- a/features/self-care/screens/BodyVitalScreen.tsx
+++ b/features/self-care/screens/BodyVitalScreen.tsx
@@ -1,5 +1,12 @@
-import React, { useContext, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
+  ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -18,6 +25,7 @@ import { ScreenView } from "@/components/ui/theme-components/ScreenView";
 import AppHeader from "@/components/layout/AppHeader";
 import { ROUTES } from "@/constants/routes";
 import { useNimbusToast } from "@/components/ui/toast/useNimbusToast";
+import { useAuth } from "@/contexts/AuthContext";
 import type { ColorSet, Spacing, Typography } from "@/theme/types";
 
 import {
@@ -27,25 +35,28 @@ import {
   InsightCard,
   NumericMetricTile,
   NumericMetricTileFooter,
-  calculateMaintenanceCalories,
-  calculateProteinTarget,
   clampHeightCm,
   deriveArchitecture,
   parseMetricNumber,
   sanitizeDecimalInput,
   sanitizeIntegerInput,
   stepWeight,
-  type SomaticGender,
-  type SomaticInsight,
 } from "@/features/self-care/components/body-vitals";
-
-const INITIAL_VALUES = {
-  gender: "masculine" as SomaticGender,
-  age: "32",
-  weight: "74.5",
-  height: "182",
-  activityLevel: 0.68,
-};
+import type { BodyVitalsContext } from "@/features/self-care/types/bodyVitals";
+import { buildBodyVitalsUpdatePayload } from "@/features/self-care/services/bodyVitalsService";
+import {
+  DEFAULT_BODY_VITALS_FORM,
+  getStoredBodyVitalsContext,
+  resolveBodyVitalsFormState,
+} from "@/features/self-care/services/bodyVitalsStorage";
+import {
+  buildCaloriePanelRouteParams,
+  resolveCaloriePanelDataFromContext,
+} from "@/features/self-care/services/caloriePanelService";
+import {
+  buildProteinPanelRouteParams,
+  resolveProteinPanelDataFromContext,
+} from "@/features/self-care/services/proteinPanelService";
 
 export default function BodyVitalScreen() {
   const { width: windowWidth } = useWindowDimensions();
@@ -55,49 +66,50 @@ export default function BodyVitalScreen() {
     [newTheme, spacing, typography, windowWidth]
   );
 
+  const { updateProfile } = useAuth();
   const toast = useNimbusToast();
+  const [savedVitalsContext, setSavedVitalsContext] =
+    useState<BodyVitalsContext | null>(null);
+  const [form, setForm] = useState(DEFAULT_BODY_VITALS_FORM);
+  const [isSaving, setIsSaving] = useState(false);
 
-  const [gender, setGender] = useState<SomaticGender>(INITIAL_VALUES.gender);
-  const [age, setAge] = useState(INITIAL_VALUES.age);
-  const [weight, setWeight] = useState(INITIAL_VALUES.weight);
-  const [height, setHeight] = useState(INITIAL_VALUES.height);
-  const [activityLevel, setActivityLevel] = useState(
-    INITIAL_VALUES.activityLevel
-  );
+  useEffect(() => {
+    let active = true;
+
+    const loadSavedVitals = async () => {
+      const cachedVitals = await getStoredBodyVitalsContext();
+
+      if (!active) {
+        return;
+      }
+
+      setSavedVitalsContext(cachedVitals);
+
+      if (cachedVitals) {
+        setForm(resolveBodyVitalsFormState(cachedVitals));
+      }
+    };
+
+    void loadSavedVitals();
+
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const numericProfile = useMemo(() => {
-    const parsedAge = parseMetricNumber(age, 32);
-    const parsedWeight = parseMetricNumber(weight, 74.5);
-    const parsedHeight = clampHeightCm(parseMetricNumber(height, 182));
+    const parsedAge = parseMetricNumber(form.age, 32);
+    const parsedWeight = parseMetricNumber(form.weight, 74.5);
+    const parsedHeight = clampHeightCm(parseMetricNumber(form.height, 182));
 
     return {
       age: parsedAge,
       weight: parsedWeight,
       height: parsedHeight,
-      gender,
-      activityLevel,
+      gender: form.gender,
+      activityLevel: form.activityLevel,
     };
-  }, [age, gender, height, activityLevel, weight]);
-
-  const proteinTarget = useMemo(() => {
-    return calculateProteinTarget(numericProfile.weight, numericProfile.activityLevel);
-  }, [numericProfile.activityLevel, numericProfile.weight]);
-
-  const calorieThreshold = useMemo(() => {
-    return calculateMaintenanceCalories({
-      age: numericProfile.age,
-      heightCm: numericProfile.height,
-      weightKg: numericProfile.weight,
-      gender: numericProfile.gender,
-      activityLevel: numericProfile.activityLevel,
-    });
-  }, [
-    numericProfile.activityLevel,
-    numericProfile.age,
-    numericProfile.gender,
-    numericProfile.height,
-    numericProfile.weight,
-  ]);
+  }, [form]);
 
   const architecture = useMemo(() => {
     return deriveArchitecture({
@@ -111,53 +123,123 @@ export default function BodyVitalScreen() {
     numericProfile.weight,
   ]);
 
-  const insights = useMemo<SomaticInsight[]>(
+  const bannerMessage = savedVitalsContext
+    ? savedVitalsContext.banner?.show && savedVitalsContext.banner.message
+      ? savedVitalsContext.banner.message
+      : "Prefilled from your saved vitals data."
+    : null;
+
+  const bannerMeta = useMemo(() => {
+    if (!savedVitalsContext) {
+      return null;
+    }
+
+    if (typeof savedVitalsContext.days_since_last_update === "number") {
+      return `Last updated ${savedVitalsContext.days_since_last_update} days ago`;
+    }
+
+    if (savedVitalsContext.profile_status) {
+      return `Profile status: ${savedVitalsContext.profile_status}`;
+    }
+
+    return null;
+  }, [savedVitalsContext]);
+
+  const proteinPanelData = useMemo(
+    () => resolveProteinPanelDataFromContext(savedVitalsContext),
+    [savedVitalsContext]
+  );
+
+  const caloriePanelData = useMemo(
+    () => resolveCaloriePanelDataFromContext(savedVitalsContext),
+    [savedVitalsContext]
+  );
+
+  const insights = useMemo(
     () => [
       {
         key: "protein",
         label: "Protein Intake",
-        value: `${proteinTarget}g / Day`,
-        icon: "flash",
+        value: `${proteinPanelData.totalRequirement} ${proteinPanelData.unit} / Day`,
+        icon: "flash" as const,
         accent: newTheme.chart4 ?? newTheme.error,
         route: ROUTES.AUTH.SELF_CARE_PROTEIN,
       },
       {
         key: "calorie",
-        label: "Calorie Threshold",
-        value: `${calorieThreshold} kcal`,
-        icon: "flame",
+        label: "Calorie Intake",
+        value: `${caloriePanelData.totalCalorie} ${caloriePanelData.unit} / Day`,
+        icon: "flame" as const,
         accent: newTheme.chart3 ?? newTheme.warning,
         route: ROUTES.AUTH.SELF_CARE_CALORIE_THRESHOLD,
       },
-        {
-          key: "architecture",
-          label: "Body Architecture",
-          value: architecture,
-          icon: "body-outline",
-          accent: newTheme.chart5 ?? newTheme.success,
-          route: ROUTES.AUTH.SELF_CARE_BODY_ARCHITECTURE,
-        },
+      {
+        key: "architecture",
+        label: "Body Architecture",
+        value: architecture,
+        icon: "body-outline" as const,
+        accent: newTheme.chart5 ?? newTheme.success,
+        route: ROUTES.AUTH.SELF_CARE_BODY_ARCHITECTURE,
+      },
     ],
     [
       architecture,
-      calorieThreshold,
       newTheme.chart3,
       newTheme.chart4,
       newTheme.chart5,
       newTheme.error,
       newTheme.warning,
       newTheme.success,
-      proteinTarget,
+      proteinPanelData.totalRequirement,
+      proteinPanelData.unit,
+      caloriePanelData.totalCalorie,
+      caloriePanelData.unit,
     ]
   );
 
-  const handleGenerateSummary = () => {
-    toast.show({
-      variant: "success",
-      title: "Biological summary generated",
-      message: "Protein, calorie, and architecture outputs are ready.",
-    });
-  };
+  const handleGenerateSummary = useCallback(async () => {
+    if (isSaving) return;
+
+    setIsSaving(true);
+
+    try {
+      const contextForPayload =
+        savedVitalsContext ?? (await getStoredBodyVitalsContext());
+      const payload = buildBodyVitalsUpdatePayload(form, contextForPayload);
+      const result = await updateProfile?.(payload);
+
+      if (result?.success) {
+        const refreshedContext = await getStoredBodyVitalsContext();
+        setSavedVitalsContext(refreshedContext);
+
+        if (refreshedContext) {
+          setForm(resolveBodyVitalsFormState(refreshedContext));
+        }
+
+        toast.show({
+          variant: "success",
+          title: "Vitals saved",
+          message: "Your body vitals were sent to your profile.",
+        });
+        return;
+      }
+
+      toast.show({
+        variant: "error",
+        title: "Unable to save vitals",
+        message: result?.message ?? "Please try again.",
+      });
+    } catch (error) {
+      console.warn("body vitals save error", error);
+      toast.show({
+        variant: "error",
+        title: "Unable to save vitals",
+        message: "Please try again.",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [form, isSaving, savedVitalsContext, toast, updateProfile]);
 
   return (
     <ScreenView padding={0} bgColor={newTheme.background} style={styles.screen}>
@@ -183,14 +265,40 @@ export default function BodyVitalScreen() {
             }}
           />
 
+          {bannerMessage ? (
+            <View style={styles.bannerCard}>
+              <LinearGradient
+                colors={["rgba(163,190,140,0.18)", "rgba(125,164,116,0.06)"]}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 1 }}
+                pointerEvents="none"
+                style={StyleSheet.absoluteFillObject}
+              />
+              <Text style={styles.bannerLabel}>SAVED VITALS PROFILE</Text>
+              <Text style={styles.bannerText}>{bannerMessage}</Text>
+              {bannerMeta ? <Text style={styles.bannerMeta}>{bannerMeta}</Text> : null}
+            </View>
+          ) : null}
+
           <View style={styles.grid}>
-            <GenderTile value={gender} onChange={setGender} style={styles.gridTile} />
+            <GenderTile
+              value={form.gender}
+              onChange={(gender) =>
+                setForm((current) => ({ ...current, gender }))
+              }
+              style={styles.gridTile}
+            />
 
             <NumericMetricTile
               accentTint="rgba(163,190,140,0.12)"
               label="Age"
-              value={age}
-              onChangeText={(text) => setAge(sanitizeIntegerInput(text))}
+              value={form.age}
+              onChangeText={(text) =>
+                setForm((current) => ({
+                  ...current,
+                  age: sanitizeIntegerInput(text),
+                }))
+              }
               keyboardType="number-pad"
               maxLength={3}
               trailingIcon="ellipsis-vertical"
@@ -200,15 +308,30 @@ export default function BodyVitalScreen() {
             <NumericMetricTile
               accentTint="rgba(163,190,140,0.10)"
               label="Weight"
-              value={weight}
-              onChangeText={(text) => setWeight(sanitizeDecimalInput(text, 1))}
+              value={form.weight}
+              onChangeText={(text) =>
+                setForm((current) => ({
+                  ...current,
+                  weight: sanitizeDecimalInput(text, 1),
+                }))
+              }
               keyboardType="decimal-pad"
               maxLength={5}
               style={styles.gridTile}
               footer={
                 <NumericMetricTileFooter.StepperRow
-                  onDecrement={() => setWeight((current) => stepWeight(current, -0.5))}
-                  onIncrement={() => setWeight((current) => stepWeight(current, 0.5))}
+                  onDecrement={() =>
+                    setForm((current) => ({
+                      ...current,
+                      weight: stepWeight(current.weight, -0.5),
+                    }))
+                  }
+                  onIncrement={() =>
+                    setForm((current) => ({
+                      ...current,
+                      weight: stepWeight(current.weight, 0.5),
+                    }))
+                  }
                 />
               }
             />
@@ -216,12 +339,17 @@ export default function BodyVitalScreen() {
             <NumericMetricTile
               accentTint="rgba(125,164,116,0.12)"
               label="Height"
-              value={height}
-              onChangeText={(text) => setHeight(sanitizeIntegerInput(text))}
+              value={form.height}
+              onChangeText={(text) =>
+                setForm((current) => ({
+                  ...current,
+                  height: sanitizeIntegerInput(text),
+                }))
+              }
               onBlur={() =>
-                setHeight((current) => {
-                  const next = clampHeightCm(parseMetricNumber(current, 182));
-                  return String(next);
+                setForm((current) => {
+                  const next = clampHeightCm(parseMetricNumber(current.height, 182));
+                  return { ...current, height: String(next) };
                 })
               }
               keyboardType="number-pad"
@@ -231,15 +359,22 @@ export default function BodyVitalScreen() {
               footer={
                 <HeightSlider
                   value={numericProfile.height}
-                  onChange={(next) => setHeight(String(next))}
+                  onChange={(next) =>
+                    setForm((current) => ({
+                      ...current,
+                      height: String(next),
+                    }))
+                  }
                 />
               }
             />
           </View>
 
           <ActivityLevelCard
-            value={activityLevel}
-            onChange={setActivityLevel}
+            value={form.activityLevel}
+            onChange={(activityLevel) =>
+              setForm((current) => ({ ...current, activityLevel }))
+            }
           />
 
           <View style={styles.sectionHeaderRow}>
@@ -258,7 +393,12 @@ export default function BodyVitalScreen() {
                   item.key === "protein"
                     ? router.push({
                         pathname: item.route ?? ROUTES.TABS.HOME,
-                        params: { protein: String(proteinTarget) },
+                        params: buildProteinPanelRouteParams(proteinPanelData),
+                      })
+                    : item.key === "calorie"
+                    ? router.push({
+                        pathname: item.route ?? ROUTES.TABS.HOME,
+                        params: buildCaloriePanelRouteParams(caloriePanelData),
                       })
                     : router.push(item.route ?? ROUTES.TABS.HOME)
                 }
@@ -269,9 +409,13 @@ export default function BodyVitalScreen() {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Generate biological summary"
-            onPress={handleGenerateSummary}
+            onPress={() => {
+              void handleGenerateSummary();
+            }}
+            disabled={isSaving}
             style={({ pressed }) => [
               styles.primaryButton,
+              isSaving && styles.primaryButtonDisabled,
               pressed && styles.primaryButtonPressed,
             ]}
           >
@@ -282,9 +426,16 @@ export default function BodyVitalScreen() {
               pointerEvents="none"
               style={StyleSheet.absoluteFillObject}
             />
-            <Text style={styles.primaryButtonText}>
-              GENERATE BIOLOGICAL SUMMARY
-            </Text>
+            {isSaving ? (
+              <View style={styles.primaryButtonContent}>
+                <ActivityIndicator color={newTheme.buttonPrimaryText} />
+                <Text style={styles.primaryButtonText}>SAVING VITALS</Text>
+              </View>
+            ) : (
+              <Text style={styles.primaryButtonText}>
+                GENERATE BIOLOGICAL SUMMARY
+              </Text>
+            )}
           </Pressable>
         </ScrollView>
       </KeyboardAvoidingView>
@@ -309,6 +460,36 @@ const styling = (
     content: {
       paddingHorizontal: spacing.md,
       paddingBottom: spacing.xl * 2.25,
+    },
+    bannerCard: {
+      borderRadius: 20,
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.md,
+      overflow: "hidden",
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: theme.borderMuted ?? theme.border,
+      backgroundColor: theme.surfaceMuted ?? "rgba(163,190,140,0.08)",
+      marginTop: spacing.sm,
+      marginBottom: spacing.md,
+      gap: spacing.xs,
+    },
+    bannerLabel: {
+      ...typography.smallCaption,
+      color: theme.textSecondary,
+      letterSpacing: 1.6,
+      fontWeight: "700",
+      opacity: 0.92,
+    },
+    bannerText: {
+      ...typography.body,
+      color: theme.textPrimary,
+      lineHeight: 20,
+    },
+    bannerMeta: {
+      ...typography.smallCaption,
+      color: theme.textSecondary,
+      opacity: 0.8,
+      letterSpacing: 0.4,
     },
     grid: {
       flexDirection: "row",
@@ -353,9 +534,17 @@ const styling = (
       shadowRadius: 18,
       elevation: 6,
     },
+    primaryButtonDisabled: {
+      opacity: 0.86,
+    },
     primaryButtonPressed: {
       opacity: 0.96,
       transform: [{ scale: 0.99 }],
+    },
+    primaryButtonContent: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.sm,
     },
     primaryButtonText: {
       color: theme.buttonPrimaryText,

--- a/features/self-care/screens/CalorieThresholdScreen.tsx
+++ b/features/self-care/screens/CalorieThresholdScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
 import {
   Pressable,
   ScrollView,
@@ -16,77 +16,63 @@ import ThemeContext from "@/contexts/ThemeContext";
 import AppHeader from "@/components/layout/AppHeader";
 import { ScreenView } from "@/components/ui/theme-components/ScreenView";
 import { ROUTES } from "@/constants/routes";
+import { getStoredBodyVitalsContext } from "@/features/self-care/services/bodyVitalsStorage";
+import type { BodyVitalsContext } from "@/features/self-care/types/bodyVitals";
+import {
+  buildCaloriePanelTiers,
+  resolveCaloriePanelDataFromContext,
+  resolveCaloriePanelDataFromParams,
+  type CaloriePanelParams,
+} from "@/features/self-care/services/caloriePanelService";
 import type { ColorSet, Spacing, Typography } from "@/theme/types";
-
-const DEFAULT_MAINTENANCE_CALORIES = 2150;
-
-const roundToNearestFifty = (value: number) =>
-  Math.max(0, Math.round(value / 50) * 50);
-
-const readFirstParam = (value: string | string[] | undefined) =>
-  Array.isArray(value) ? value[0] : value;
-
-type CalorieTier = {
-  key: string;
-  label: string;
-  title: string;
-  calories: number;
-  highlight?: boolean;
-};
 
 export default function CalorieThresholdScreen() {
   const { newTheme, spacing, typography } = useContext(ThemeContext);
   const { width } = useWindowDimensions();
   const params = useLocalSearchParams();
+  const [savedVitalsContext, setSavedVitalsContext] =
+    useState<BodyVitalsContext | null>(null);
 
-  const maintenanceCalories = useMemo(() => {
-    const raw =
-      readFirstParam(
-        params.maintenanceCalories as string | string[] | undefined
-      ) ??
-      readFirstParam(params.calories as string | string[] | undefined) ??
-      readFirstParam(params.targetCalories as string | string[] | undefined) ??
-      readFirstParam(params.maintenance as string | string[] | undefined);
+  useEffect(() => {
+    let active = true;
 
-    const parsed = Number.parseInt(raw ?? "", 10);
-    return Number.isFinite(parsed) && parsed > 0
-      ? parsed
-      : DEFAULT_MAINTENANCE_CALORIES;
-  }, [
-    params.calories,
-    params.maintenance,
-    params.maintenanceCalories,
-    params.targetCalories,
-  ]);
+    const loadSavedVitals = async () => {
+      const cachedVitals = await getStoredBodyVitalsContext();
 
-  const calorieTiers = useMemo<CalorieTier[]>(() => {
-    const burnCalories = roundToNearestFifty(
-      Math.max(0, maintenanceCalories - 300)
-    );
-    const buildCalories = roundToNearestFifty(maintenanceCalories + 250);
+      if (!active) {
+        return;
+      }
 
-    return [
-      {
-        key: "maintenance",
-        label: "METABOLIC FLUX",
-        title: "Maintenance",
-        calories: maintenanceCalories,
-      },
-      {
-        key: "burn",
-        label: "OPTIMAL IGNITION",
-        title: "Burn (Fat Loss)",
-        calories: burnCalories,
-        highlight: true,
-      },
-      {
-        key: "build",
-        label: "STRUCTURAL GROWTH",
-        title: "Build (Muscle)",
-        calories: buildCalories,
-      },
-    ];
-  }, [maintenanceCalories]);
+      setSavedVitalsContext(cachedVitals);
+    };
+
+    void loadSavedVitals();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const routeCalorieData = useMemo(
+    () =>
+      resolveCaloriePanelDataFromParams(
+        params as unknown as CaloriePanelParams
+      ),
+    [params]
+  );
+
+  const savedCalorieData = useMemo(
+    () => resolveCaloriePanelDataFromContext(savedVitalsContext),
+    [savedVitalsContext]
+  );
+
+  const calorieData =
+    routeCalorieData.source === "api" ? routeCalorieData : savedCalorieData;
+
+  const calorieTiers = useMemo(
+    () => buildCaloriePanelTiers(calorieData),
+    [calorieData]
+  );
 
   const heroWidth = Math.min(Math.max(width * 0.68, 208), 244);
   const heroHeight = 96;
@@ -97,15 +83,11 @@ export default function CalorieThresholdScreen() {
   );
 
   const handleSealToPlan = () => {
-    const burnCalories = roundToNearestFifty(
-      Math.max(0, maintenanceCalories - 300)
-    );
-
     router.push({
       pathname: ROUTES.AUTH.TOOLS_MEAL_PLANNER,
       params: {
-        maintenanceCalories: String(maintenanceCalories),
-        targetCalories: String(burnCalories),
+        maintenanceCalories: String(calorieData.maintenanceCalories),
+        targetCalories: String(calorieData.optimalBurnCalories),
       },
     });
   };
@@ -152,9 +134,10 @@ export default function CalorieThresholdScreen() {
             />
 
             <Text style={styles.heroValue}>
-              {maintenanceCalories}
-              <Text style={styles.heroUnit}> kcal</Text>
+              {calorieData.totalCalorie}
+              <Text style={styles.heroUnit}> {calorieData.unit}</Text>
             </Text>
+            <Text style={styles.heroCaption}>TOTAL CALORIES</Text>
           </View>
         </View>
 
@@ -196,7 +179,7 @@ export default function CalorieThresholdScreen() {
                 ]}
               >
                 {tier.calories}
-                <Text style={styles.cardCaloriesUnit}> kcal</Text>
+                <Text style={styles.cardCaloriesUnit}> {calorieData.unit}</Text>
               </Text>
             </View>
           ))}
@@ -204,7 +187,8 @@ export default function CalorieThresholdScreen() {
 
         <View style={styles.tipWrap}>
           <Text style={styles.tipText}>
-            This formula is synthesized from your maintenance estimate.
+            {calorieData.tip}
+            {"\n"}
             Assign the selected Burn target to your Nourish Plan to begin.
           </Text>
         </View>
@@ -304,6 +288,16 @@ const styling = (
       lineHeight: 24,
       fontStyle: "italic",
       letterSpacing: -0.4,
+    },
+    heroCaption: {
+      marginTop: 2,
+      color: themeInk,
+      fontFamily: typography.smallCaption.fontFamily,
+      fontSize: 10,
+      lineHeight: 12,
+      fontWeight: "800",
+      letterSpacing: 2.4,
+      opacity: 0.88,
     },
     sectionTitle: {
       color: theme.textPrimary,

--- a/features/self-care/screens/ProteinCalculatorScreen.tsx
+++ b/features/self-care/screens/ProteinCalculatorScreen.tsx
@@ -16,81 +16,37 @@ import AppHeader from "@/components/layout/AppHeader";
 import { ScreenView } from "@/components/ui/theme-components/ScreenView";
 import { ROUTES } from "@/constants/routes";
 import type { ColorSet, Spacing, Typography } from "@/theme/types";
-
-const DEFAULT_PROTEIN_TARGET = 165;
-
-const roundToNearestFive = (value: number) => Math.max(0, Math.round(value / 5) * 5);
-
-const readFirstParam = (value: string | string[] | undefined) =>
-  Array.isArray(value) ? value[0] : value;
-
-const buildProteinSlots = (proteinTarget: number) => {
-  const first = roundToNearestFive(proteinTarget * 0.24);
-  const second = roundToNearestFive(proteinTarget * 0.39);
-  let third = proteinTarget - first - second;
-
-  if (third < 0) {
-    const overflow = Math.abs(third);
-    const adjustedSecond = Math.max(0, second - overflow);
-    third = proteinTarget - first - adjustedSecond;
-
-    return [
-      {
-        key: "slot-1",
-        label: "SLOT 1 (BREAKING FAST)",
-        grams: first,
-      },
-      {
-        key: "slot-2",
-        label: "SLOT 2 (MID-DAY FUEL)",
-        grams: adjustedSecond,
-      },
-      {
-        key: "slot-3",
-        label: "SLOT 3 (EVENING REPAIR)",
-        grams: third,
-      },
-    ];
-  }
-
-  return [
-    {
-      key: "slot-1",
-      label: "SLOT 1 (BREAKING FAST)",
-      grams: first,
-    },
-    {
-      key: "slot-2",
-      label: "SLOT 2 (MID-DAY FUEL)",
-      grams: second,
-    },
-    {
-      key: "slot-3",
-      label: "SLOT 3 (EVENING REPAIR)",
-      grams: third,
-    },
-  ];
-};
+import {
+  buildProteinPanelMealSlots,
+  resolveProteinPanelDataFromParams,
+} from "@/features/self-care/services/proteinPanelService";
 
 export const ProteinCalculatorScreen = () => {
   const { newTheme, spacing, typography } = useContext(ThemeContext);
-  const { width } = useWindowDimensions();
   const params = useLocalSearchParams();
+  const { width } = useWindowDimensions();
 
-  const proteinTarget = useMemo(() => {
-    const parsed = Number.parseInt(
-      readFirstParam(params.protein as string | string[] | undefined) ?? "",
-      10
-    );
-
-    return Number.isFinite(parsed) && parsed > 0
-      ? parsed
-      : DEFAULT_PROTEIN_TARGET;
-  }, [params.protein]);
+  const proteinPanelData = useMemo(
+    () =>
+      resolveProteinPanelDataFromParams(
+        params as {
+          total_requirement?: string | string[];
+          meal_one?: string | string[];
+          meal_two?: string | string[];
+          meal_three?: string | string[];
+          unit?: string | string[];
+          tip?: string | string[];
+          protein?: string | string[];
+        }
+      ),
+    [
+      params,
+    ]
+  );
 
   const proteinSlots = useMemo(
-    () => buildProteinSlots(proteinTarget),
-    [proteinTarget]
+    () => buildProteinPanelMealSlots(proteinPanelData),
+    [proteinPanelData]
   );
 
   const heroSize = Math.min(Math.max(width * 0.64, 198), 226);
@@ -103,7 +59,7 @@ export const ProteinCalculatorScreen = () => {
   const handleSealToPlan = () => {
     router.push({
       pathname: ROUTES.AUTH.TOOLS_MEAL_PLANNER,
-      params: { protein: String(proteinTarget) },
+      params: { protein: String(proteinPanelData.totalRequirement) },
     });
   };
 
@@ -144,10 +100,10 @@ export const ProteinCalculatorScreen = () => {
             />
 
             <Text style={styles.heroValue}>
-              {proteinTarget}
-              <Text style={styles.heroUnit}>g</Text>
+              {proteinPanelData.totalRequirement}
+              <Text style={styles.heroUnit}> {proteinPanelData.unit}</Text>
             </Text>
-            <Text style={styles.heroCaption}>DAILY STRUCTURAL REQUIREMENT</Text>
+            <Text style={styles.heroCaption}>TOTAL REQUIREMENT</Text>
           </View>
         </View>
 
@@ -169,7 +125,7 @@ export const ProteinCalculatorScreen = () => {
               <View style={styles.slotAmountColumn}>
                 <Text style={styles.slotAmount}>
                   {slot.grams}
-                  <Text style={styles.slotUnit}>g</Text>
+                  <Text style={styles.slotUnit}> {proteinPanelData.unit}</Text>
                 </Text>
                 <Text style={styles.slotAmountLabel}>Protein</Text>
               </View>
@@ -179,8 +135,7 @@ export const ProteinCalculatorScreen = () => {
 
         <View style={styles.tipWrap}>
           <Text style={styles.tipText}>
-            This formula is optimized for Lean Body Mass maintenance and Neural
-            Recovery.
+            {proteinPanelData.tip}
             {"\n"}
             Assign these values to your Nourish Plan to begin.
           </Text>

--- a/features/self-care/services/__tests__/bodyVitalsService.test.ts
+++ b/features/self-care/services/__tests__/bodyVitalsService.test.ts
@@ -1,0 +1,57 @@
+import { buildBodyVitalsUpdatePayload } from "../bodyVitalsService";
+
+describe("bodyVitalsService", () => {
+  it("builds the patch payload from the current form and saved vitals context", () => {
+    const payload = buildBodyVitalsUpdatePayload(
+      {
+        gender: "feminine",
+        age: "",
+        weight: "",
+        height: "",
+        activityLevel: 0.68,
+      },
+      {
+        prefill: {
+          gender: "female",
+          age: 28,
+          weight_kg: 64.5,
+          height_cm: 172,
+          activity_level: "active",
+        },
+      }
+    );
+
+    expect(payload).toEqual({
+      calculation_type: "all",
+      save_to_profile: true,
+      vitals: {
+        gender: "female",
+        age: 28,
+        weight_kg: 64.5,
+        height_cm: 172,
+        activity_level: "active",
+      },
+    });
+  });
+
+  it("rounds values from the active form before sending them to the profile patch", () => {
+    const payload = buildBodyVitalsUpdatePayload(
+      {
+        gender: "masculine",
+        age: "28.9",
+        weight: "64.44",
+        height: "171.7",
+        activityLevel: 0.85,
+      },
+      null
+    );
+
+    expect(payload.vitals).toEqual({
+      gender: "male",
+      age: 29,
+      weight_kg: 64.4,
+      height_cm: 172,
+      activity_level: "optimal",
+    });
+  });
+});

--- a/features/self-care/services/__tests__/caloriePanelService.test.ts
+++ b/features/self-care/services/__tests__/caloriePanelService.test.ts
@@ -1,0 +1,89 @@
+import {
+  FALLBACK_CALORIE_PANEL_DATA,
+  buildCaloriePanelRouteParams,
+  buildCaloriePanelTiers,
+  resolveCaloriePanelDataFromContext,
+  resolveCaloriePanelDataFromParams,
+} from "../caloriePanelService";
+
+describe("caloriePanelService", () => {
+  it("maps the calorie goal from the vitals context", () => {
+    const data = resolveCaloriePanelDataFromContext({
+      profile: {
+        calorie_goal: {
+          total_calorie: 1949,
+          maintenance_calories: 2199,
+          optimal_burn_calories: 1949,
+          unit: "kcal",
+          maintaince: 2199,
+          burn: 1949,
+          build: 2449,
+          tip: "This is a larger deficit. Watch recovery, hunger, and training performance closely.",
+        },
+      },
+    });
+
+    expect(data).toEqual({
+      totalCalorie: 1949,
+      maintenanceCalories: 2199,
+      optimalBurnCalories: 1949,
+      buildCalories: 2449,
+      unit: "kcal",
+      tip: "This is a larger deficit. Watch recovery, hunger, and training performance closely.",
+      source: "api",
+    });
+  });
+
+  it("falls back to mock calorie data when no saved values exist", () => {
+    expect(resolveCaloriePanelDataFromContext(null)).toEqual(
+      FALLBACK_CALORIE_PANEL_DATA
+    );
+  });
+
+  it("builds route params and tiers from the resolved calorie data", () => {
+    const data = resolveCaloriePanelDataFromParams({
+      total_calorie: "1949",
+      maintenance_calories: "2199",
+      optimal_burn_calories: "1949",
+      build: "2449",
+      unit: "kcal",
+      tip: "This is a larger deficit. Watch recovery, hunger, and training performance closely.",
+    });
+
+    expect(buildCaloriePanelRouteParams(data)).toEqual({
+      total_calorie: "1949",
+      maintenance_calories: "2199",
+      optimal_burn_calories: "1949",
+      build: "2449",
+      unit: "kcal",
+      tip: "This is a larger deficit. Watch recovery, hunger, and training performance closely.",
+      calories: "1949",
+      maintenanceCalories: "2199",
+      targetCalories: "1949",
+      maintenance: "2199",
+      burn: "1949",
+    });
+
+    expect(buildCaloriePanelTiers(data)).toEqual([
+      {
+        key: "maintenance",
+        label: "METABOLIC FLUX",
+        title: "Maintenance",
+        calories: 2199,
+      },
+      {
+        key: "burn",
+        label: "OPTIMAL IGNITION",
+        title: "Burn (Fat Loss)",
+        calories: 1949,
+        highlight: true,
+      },
+      {
+        key: "build",
+        label: "STRUCTURAL GROWTH",
+        title: "Build (Muscle)",
+        calories: 2449,
+      },
+    ]);
+  });
+});

--- a/features/self-care/services/__tests__/proteinPanelService.test.ts
+++ b/features/self-care/services/__tests__/proteinPanelService.test.ts
@@ -1,0 +1,67 @@
+import {
+  FALLBACK_PROTEIN_PANEL_DATA,
+  buildProteinPanelMealSlots,
+  buildProteinPanelRouteParams,
+  resolveProteinPanelDataFromContext,
+  resolveProteinPanelDataFromParams,
+} from "../proteinPanelService";
+
+describe("proteinPanelService", () => {
+  it("maps the protein goal from the vitals context", () => {
+    const data = resolveProteinPanelDataFromContext({
+      profile: {
+        protein_goal: {
+          total_requirement: 124,
+          meal_one: 29,
+          meal_two: 34,
+          meal_three: 28,
+          unit: "gm",
+          tip: "Anchor each meal with a clear protein source.",
+        },
+      },
+    });
+
+    expect(data).toEqual({
+      totalRequirement: 124,
+      mealOne: 29,
+      mealTwo: 34,
+      mealThree: 28,
+      unit: "gm",
+      tip: "Anchor each meal with a clear protein source.",
+      source: "api",
+    });
+  });
+
+  it("falls back to the mock protein data when the API payload is missing", () => {
+    expect(resolveProteinPanelDataFromContext(null)).toEqual(
+      FALLBACK_PROTEIN_PANEL_DATA
+    );
+  });
+
+  it("builds route params and meal slots from the resolved data", () => {
+    const data = resolveProteinPanelDataFromParams({
+      total_requirement: "140",
+      meal_one: "35",
+      meal_two: "45",
+      meal_three: "60",
+      unit: "g",
+      tip: "Keep meals protein-forward.",
+    });
+
+    expect(buildProteinPanelRouteParams(data)).toEqual({
+      protein: "140",
+      total_requirement: "140",
+      meal_one: "35",
+      meal_two: "45",
+      meal_three: "60",
+      unit: "g",
+      tip: "Keep meals protein-forward.",
+    });
+
+    expect(buildProteinPanelMealSlots(data)).toEqual([
+      { key: "meal-1", label: "MEAL 1", grams: 35 },
+      { key: "meal-2", label: "MEAL 2", grams: 45 },
+      { key: "meal-3", label: "MEAL 3", grams: 60 },
+    ]);
+  });
+});

--- a/features/self-care/services/bodyVitalsService.ts
+++ b/features/self-care/services/bodyVitalsService.ts
@@ -1,0 +1,57 @@
+import {
+  clampHeightCm,
+  getActivityOption,
+  parseMetricNumber,
+} from "@/features/self-care/components/body-vitals/utils";
+import type { BodyVitalsContext, BodyVitalsFormState, BodyVitalsUpdatePayload } from "@/features/self-care/types/bodyVitals";
+
+import { DEFAULT_BODY_VITALS_FORM, resolveBodyVitalsFormState } from "./bodyVitalsStorage";
+
+export function mapSomaticGenderToApiGender(
+  gender: BodyVitalsFormState["gender"]
+) {
+  return gender === "feminine" ? "female" : "male";
+}
+
+export function buildBodyVitalsUpdatePayload(
+  form: BodyVitalsFormState,
+  savedContext: BodyVitalsContext | null
+): BodyVitalsUpdatePayload {
+  const fallback = resolveBodyVitalsFormState(
+    savedContext,
+    DEFAULT_BODY_VITALS_FORM
+  );
+
+  const age = parseMetricNumber(
+    form.age,
+    parseMetricNumber(fallback.age, parseMetricNumber(DEFAULT_BODY_VITALS_FORM.age, 32))
+  );
+  const weightKg = parseMetricNumber(
+    form.weight,
+    parseMetricNumber(
+      fallback.weight,
+      parseMetricNumber(DEFAULT_BODY_VITALS_FORM.weight, 74.5)
+    )
+  );
+  const heightCm = clampHeightCm(
+    parseMetricNumber(
+      form.height,
+      parseMetricNumber(
+        fallback.height,
+        parseMetricNumber(DEFAULT_BODY_VITALS_FORM.height, 182)
+      )
+    )
+  );
+
+  return {
+    calculation_type: "all",
+    save_to_profile: true,
+    vitals: {
+      gender: mapSomaticGenderToApiGender(form.gender),
+      age: Math.round(age),
+      weight_kg: Number(weightKg.toFixed(1)),
+      height_cm: Math.round(heightCm),
+      activity_level: getActivityOption(form.activityLevel).key,
+    },
+  };
+}

--- a/features/self-care/services/bodyVitalsStorage.ts
+++ b/features/self-care/services/bodyVitalsStorage.ts
@@ -1,0 +1,207 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import { StoreKey } from "@/constants/Constant";
+import { getStoredUser } from "@/services/storageService";
+
+import {
+  clampHeightCm,
+  formatFlexibleDecimal,
+  parseMetricNumber,
+} from "@/features/self-care/components/body-vitals/utils";
+import type { SomaticGender } from "@/features/self-care/components/body-vitals/types";
+import type {
+  BodyVitalsActivityLevel,
+  BodyVitalsContext,
+  BodyVitalsFormState,
+} from "@/features/self-care/types/bodyVitals";
+
+const BODY_VITALS_CONTEXT_KEY = StoreKey.BODY_VITALS_CONTEXT_KEY;
+
+export const DEFAULT_BODY_VITALS_FORM: BodyVitalsFormState = {
+  gender: "masculine",
+  age: "32",
+  weight: "74.5",
+  height: "182",
+  activityLevel: 0.68,
+};
+
+const ACTIVITY_LEVEL_VALUES: Record<string, number> = {
+  sedentary: 0.2,
+  active: 0.55,
+  optimal: 0.85,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function toBoolean(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    if (value === "true") return true;
+    if (value === "false") return false;
+  }
+  return null;
+}
+
+function toSomaticGender(
+  gender: unknown,
+  preferNotToSay: unknown,
+  fallback: SomaticGender = DEFAULT_BODY_VITALS_FORM.gender
+): SomaticGender {
+  if (typeof gender === "string") {
+    const normalizedGender = gender.trim().toLowerCase();
+    if (normalizedGender === "female" || normalizedGender === "feminine") {
+      return "feminine";
+    }
+    if (normalizedGender === "male" || normalizedGender === "masculine") {
+      return "masculine";
+    }
+  }
+
+  if (toBoolean(preferNotToSay)) {
+    return fallback;
+  }
+
+  return fallback;
+}
+
+function toActivityLevel(
+  value: BodyVitalsActivityLevel | null | undefined,
+  fallback = DEFAULT_BODY_VITALS_FORM.activityLevel
+) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized in ACTIVITY_LEVEL_VALUES) {
+      return ACTIVITY_LEVEL_VALUES[normalized];
+    }
+
+    const parsed = Number(normalized);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return fallback;
+}
+
+export function normalizeBodyVitalsContext(raw: unknown): BodyVitalsContext | null {
+  return isRecord(raw) ? (raw as BodyVitalsContext) : null;
+}
+
+export async function setStoredBodyVitalsContext(
+  context: BodyVitalsContext | null
+): Promise<void> {
+  if (!context) {
+    await AsyncStorage.removeItem(BODY_VITALS_CONTEXT_KEY);
+    return;
+  }
+
+  await AsyncStorage.setItem(BODY_VITALS_CONTEXT_KEY, JSON.stringify(context));
+}
+
+export async function clearStoredBodyVitalsContext(): Promise<void> {
+  await AsyncStorage.removeItem(BODY_VITALS_CONTEXT_KEY);
+}
+
+export async function getStoredBodyVitalsContext(): Promise<BodyVitalsContext | null> {
+  const cachedRaw = await AsyncStorage.getItem(BODY_VITALS_CONTEXT_KEY);
+  let cached: BodyVitalsContext | null = null;
+
+  try {
+    cached = normalizeBodyVitalsContext(cachedRaw ? JSON.parse(cachedRaw) : null);
+  } catch {
+    cached = null;
+  }
+
+  if (cached) {
+    return cached;
+  }
+
+  const storedUser = await getStoredUser();
+  const storedContext = normalizeBodyVitalsContext(storedUser?.vitals_context);
+  if (!storedContext) {
+    return null;
+  }
+
+  await setStoredBodyVitalsContext(storedContext);
+  return storedContext;
+}
+
+export async function syncStoredBodyVitalsContext(source: {
+  vitals_context?: unknown;
+} | null | undefined): Promise<void> {
+  if (!source) {
+    await clearStoredBodyVitalsContext();
+    return;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(source, "vitals_context")) {
+    return;
+  }
+
+  await setStoredBodyVitalsContext(
+    normalizeBodyVitalsContext(source.vitals_context)
+  );
+}
+
+export function resolveBodyVitalsFormState(
+  context: BodyVitalsContext | null | undefined,
+  fallback: BodyVitalsFormState = DEFAULT_BODY_VITALS_FORM
+): BodyVitalsFormState {
+  const prefill = context?.prefill;
+  const profile = context?.profile;
+  const savedSummary = context?.saved_summary;
+
+  const heightCm =
+    toNumber(prefill?.height_cm) ??
+    toNumber(savedSummary?.height_cm) ??
+    toNumber(profile?.height_cm);
+  const weightKg =
+    toNumber(prefill?.weight_kg) ??
+    toNumber(savedSummary?.weight_kg) ??
+    toNumber(profile?.weight_kg);
+  const age =
+    toNumber(prefill?.age) ?? toNumber(savedSummary?.age) ?? toNumber(profile?.age);
+
+  const gender = toSomaticGender(
+    prefill?.gender ?? savedSummary?.gender ?? profile?.gender,
+    prefill?.gender_prefer_not_to_say ??
+      savedSummary?.gender_prefer_not_to_say ??
+      profile?.gender_prefer_not_to_say,
+    fallback.gender
+  );
+
+  const activityLevel = toActivityLevel(
+    prefill?.activity_level ?? profile?.activity_level,
+    fallback.activityLevel
+  );
+
+  return {
+    gender,
+    age: String(Math.round(age ?? parseMetricNumber(fallback.age, 32))),
+    weight: formatFlexibleDecimal(
+      weightKg ?? parseMetricNumber(fallback.weight, 74.5),
+      1
+    ),
+    height: String(
+      clampHeightCm(
+        Math.round(heightCm ?? parseMetricNumber(fallback.height, 182))
+      )
+    ),
+    activityLevel,
+  };
+}

--- a/features/self-care/services/caloriePanelService.ts
+++ b/features/self-care/services/caloriePanelService.ts
@@ -1,0 +1,211 @@
+import type {
+  BodyVitalsCalorieGoal,
+  BodyVitalsContext,
+} from "@/features/self-care/types/bodyVitals";
+
+export type CaloriePanelData = {
+  totalCalorie: number;
+  maintenanceCalories: number;
+  optimalBurnCalories: number;
+  buildCalories: number;
+  unit: string;
+  tip: string;
+  source: "api" | "mock";
+};
+
+export type CaloriePanelTier = {
+  key: "maintenance" | "burn" | "build";
+  label: string;
+  title: string;
+  calories: number;
+  highlight?: boolean;
+};
+
+export type CaloriePanelParams = {
+  total_calorie?: string | string[];
+  maintenance_calories?: string | string[];
+  optimal_burn_calories?: string | string[];
+  build?: string | string[];
+  burn?: string | string[];
+  unit?: string | string[];
+  tip?: string | string[];
+  calories?: string | string[];
+  maintenanceCalories?: string | string[];
+  targetCalories?: string | string[];
+  maintenance?: string | string[];
+};
+
+const FALLBACK_CALORIE_PANEL_DATA: CaloriePanelData = {
+  totalCalorie: 1949,
+  maintenanceCalories: 2199,
+  optimalBurnCalories: 1949,
+  buildCalories: 2449,
+  unit: "kcal",
+  tip: "This is a larger deficit. Watch recovery, hunger, and training performance closely.",
+  source: "mock",
+};
+
+function readFirstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function toText(value: unknown, fallback: string) {
+  return typeof value === "string" && value.trim() ? value : fallback;
+}
+
+function normalizeCalorieGoal(goal?: BodyVitalsCalorieGoal | null): CaloriePanelData {
+  if (!goal) {
+    return FALLBACK_CALORIE_PANEL_DATA;
+  }
+
+  const totalCalorie =
+    toNumber(goal.total_calorie) ??
+    toNumber(goal.optimal_burn_calories) ??
+    toNumber(goal.burn) ??
+    FALLBACK_CALORIE_PANEL_DATA.totalCalorie;
+
+  const maintenanceCalories =
+    toNumber(goal.maintenance_calories) ??
+    toNumber(goal.maintaince) ??
+    Math.round(totalCalorie + 250);
+
+  const optimalBurnCalories =
+    toNumber(goal.optimal_burn_calories) ??
+    toNumber(goal.burn) ??
+    totalCalorie;
+
+  const buildCalories =
+    toNumber(goal.build) ?? Math.round(maintenanceCalories + 250);
+
+  return {
+    totalCalorie,
+    maintenanceCalories,
+    optimalBurnCalories,
+    buildCalories,
+    unit: toText(goal.unit, FALLBACK_CALORIE_PANEL_DATA.unit),
+    tip: toText(goal.tip, FALLBACK_CALORIE_PANEL_DATA.tip),
+    source: "api",
+  };
+}
+
+export function resolveCaloriePanelDataFromContext(
+  context: BodyVitalsContext | null | undefined
+): CaloriePanelData {
+  return normalizeCalorieGoal(context?.profile?.calorie_goal);
+}
+
+export function resolveCaloriePanelDataFromParams(
+  params: CaloriePanelParams
+): CaloriePanelData {
+  const totalCalorie =
+    toNumber(readFirstParam(params.total_calorie)) ??
+    toNumber(readFirstParam(params.calories)) ??
+    toNumber(readFirstParam(params.maintenanceCalories)) ??
+    toNumber(readFirstParam(params.maintenance)) ??
+    FALLBACK_CALORIE_PANEL_DATA.totalCalorie;
+
+  const maintenanceCalories =
+    toNumber(readFirstParam(params.maintenance_calories)) ??
+    toNumber(readFirstParam(params.maintenanceCalories)) ??
+    toNumber(readFirstParam(params.maintenance)) ??
+    Math.round(totalCalorie + 250);
+
+  const optimalBurnCalories =
+    toNumber(readFirstParam(params.optimal_burn_calories)) ??
+    toNumber(readFirstParam(params.targetCalories)) ??
+    toNumber(readFirstParam(params.burn)) ??
+    totalCalorie;
+
+  const buildCalories =
+    toNumber(readFirstParam(params.build)) ??
+    Math.round(maintenanceCalories + 250);
+
+  const unit = toText(
+    readFirstParam(params.unit),
+    FALLBACK_CALORIE_PANEL_DATA.unit
+  );
+  const tip = toText(
+    readFirstParam(params.tip),
+    FALLBACK_CALORIE_PANEL_DATA.tip
+  );
+
+  const hasApiParams =
+    params.total_calorie !== undefined ||
+    params.maintenance_calories !== undefined ||
+    params.optimal_burn_calories !== undefined ||
+    params.build !== undefined ||
+    params.burn !== undefined ||
+    params.unit !== undefined ||
+    params.tip !== undefined ||
+    params.calories !== undefined ||
+    params.maintenanceCalories !== undefined ||
+    params.targetCalories !== undefined ||
+    params.maintenance !== undefined;
+
+  return {
+    totalCalorie,
+    maintenanceCalories,
+    optimalBurnCalories,
+    buildCalories,
+    unit,
+    tip,
+    source: hasApiParams ? "api" : "mock",
+  };
+}
+
+export function buildCaloriePanelRouteParams(data: CaloriePanelData) {
+  return {
+    total_calorie: String(data.totalCalorie),
+    maintenance_calories: String(data.maintenanceCalories),
+    optimal_burn_calories: String(data.optimalBurnCalories),
+    build: String(data.buildCalories),
+    unit: data.unit,
+    tip: data.tip,
+    calories: String(data.totalCalorie),
+    maintenanceCalories: String(data.maintenanceCalories),
+    targetCalories: String(data.optimalBurnCalories),
+    maintenance: String(data.maintenanceCalories),
+    burn: String(data.optimalBurnCalories),
+  };
+}
+
+export function buildCaloriePanelTiers(
+  data: CaloriePanelData
+): CaloriePanelTier[] {
+  return [
+    {
+      key: "maintenance",
+      label: "METABOLIC FLUX",
+      title: "Maintenance",
+      calories: data.maintenanceCalories,
+    },
+    {
+      key: "burn",
+      label: "OPTIMAL IGNITION",
+      title: "Burn (Fat Loss)",
+      calories: data.optimalBurnCalories,
+      highlight: true,
+    },
+    {
+      key: "build",
+      label: "STRUCTURAL GROWTH",
+      title: "Build (Muscle)",
+      calories: data.buildCalories,
+    },
+  ];
+}
+
+export { FALLBACK_CALORIE_PANEL_DATA };

--- a/features/self-care/services/proteinPanelService.ts
+++ b/features/self-care/services/proteinPanelService.ts
@@ -1,0 +1,162 @@
+import type { BodyVitalsContext, BodyVitalsProteinGoal } from "@/features/self-care/types/bodyVitals";
+
+export type ProteinPanelData = {
+  totalRequirement: number;
+  mealOne: number;
+  mealTwo: number;
+  mealThree: number;
+  unit: string;
+  tip: string;
+  source: "api" | "mock";
+};
+
+export type ProteinPanelMealSlot = {
+  key: "meal-1" | "meal-2" | "meal-3";
+  label: string;
+  grams: number;
+};
+
+type ProteinPanelParams = {
+  total_requirement?: string | string[];
+  meal_one?: string | string[];
+  meal_two?: string | string[];
+  meal_three?: string | string[];
+  unit?: string | string[];
+  tip?: string | string[];
+  protein?: string | string[];
+};
+
+const FALLBACK_PROTEIN_PANEL_DATA: ProteinPanelData = {
+  totalRequirement: 124,
+  mealOne: 29,
+  mealTwo: 34,
+  mealThree: 28,
+  unit: "gm",
+  tip: "Anchor each meal with a clear protein source and keep snacks protein-forward.",
+  source: "mock",
+};
+
+function readFirstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function toText(value: unknown, fallback: string) {
+  return typeof value === "string" && value.trim() ? value : fallback;
+}
+
+function normalizeProteinGoal(goal?: BodyVitalsProteinGoal | null): ProteinPanelData {
+  if (!goal) {
+    return FALLBACK_PROTEIN_PANEL_DATA;
+  }
+
+  return {
+    totalRequirement:
+      toNumber(goal.total_requirement) ?? FALLBACK_PROTEIN_PANEL_DATA.totalRequirement,
+    mealOne: toNumber(goal.meal_one) ?? FALLBACK_PROTEIN_PANEL_DATA.mealOne,
+    mealTwo: toNumber(goal.meal_two) ?? FALLBACK_PROTEIN_PANEL_DATA.mealTwo,
+    mealThree:
+      toNumber(goal.meal_three) ?? FALLBACK_PROTEIN_PANEL_DATA.mealThree,
+    unit: toText(goal.unit, FALLBACK_PROTEIN_PANEL_DATA.unit),
+    tip: toText(goal.tip, FALLBACK_PROTEIN_PANEL_DATA.tip),
+    source: "api",
+  };
+}
+
+export function resolveProteinPanelDataFromContext(
+  context: BodyVitalsContext | null | undefined
+): ProteinPanelData {
+  return normalizeProteinGoal(context?.profile?.protein_goal);
+}
+
+export function resolveProteinPanelDataFromParams(
+  params: ProteinPanelParams
+): ProteinPanelData {
+  const totalRequirement =
+    toNumber(readFirstParam(params.total_requirement)) ??
+    toNumber(readFirstParam(params.protein)) ??
+    FALLBACK_PROTEIN_PANEL_DATA.totalRequirement;
+  const mealOne =
+    toNumber(readFirstParam(params.meal_one)) ??
+    FALLBACK_PROTEIN_PANEL_DATA.mealOne;
+  const mealTwo =
+    toNumber(readFirstParam(params.meal_two)) ??
+    FALLBACK_PROTEIN_PANEL_DATA.mealTwo;
+  const mealThree =
+    toNumber(readFirstParam(params.meal_three)) ??
+    FALLBACK_PROTEIN_PANEL_DATA.mealThree;
+  const unit = toText(
+    readFirstParam(params.unit),
+    FALLBACK_PROTEIN_PANEL_DATA.unit
+  );
+  const tip = toText(
+    readFirstParam(params.tip),
+    FALLBACK_PROTEIN_PANEL_DATA.tip
+  );
+
+  const hasApiParams =
+    params.total_requirement !== undefined ||
+    params.meal_one !== undefined ||
+    params.meal_two !== undefined ||
+    params.meal_three !== undefined ||
+    params.unit !== undefined ||
+    params.tip !== undefined;
+
+  return {
+    totalRequirement,
+    mealOne,
+    mealTwo,
+    mealThree,
+    unit,
+    tip,
+    source: hasApiParams ? "api" : "mock",
+  };
+}
+
+export function buildProteinPanelRouteParams(data: ProteinPanelData) {
+  return {
+    protein: String(data.totalRequirement),
+    total_requirement: String(data.totalRequirement),
+    meal_one: String(data.mealOne),
+    meal_two: String(data.mealTwo),
+    meal_three: String(data.mealThree),
+    unit: data.unit,
+    tip: data.tip,
+  };
+}
+
+export function buildProteinPanelMealSlots(
+  data: ProteinPanelData
+): ProteinPanelMealSlot[] {
+  return [
+    {
+      key: "meal-1",
+      label: "MEAL 1",
+      grams: data.mealOne,
+    },
+    {
+      key: "meal-2",
+      label: "MEAL 2",
+      grams: data.mealTwo,
+    },
+    {
+      key: "meal-3",
+      label: "MEAL 3",
+      grams: data.mealThree,
+    },
+  ];
+}
+
+export { FALLBACK_PROTEIN_PANEL_DATA };

--- a/features/self-care/types/bodyVitals.ts
+++ b/features/self-care/types/bodyVitals.ts
@@ -1,0 +1,135 @@
+import type { SomaticGender } from "@/features/self-care/components/body-vitals/types";
+
+export type BodyVitalsActivityLevel = "sedentary" | "active" | "optimal" | string;
+export type BodyVitalsApiGender = "male" | "female";
+export type BodyVitalsApiActivityLevel = "sedentary" | "active" | "optimal";
+
+export type BodyVitalsPrefill = {
+  height_cm?: number | null;
+  weight_kg?: number | null;
+  age?: number | null;
+  gender?: "male" | "female" | null;
+  gender_prefer_not_to_say?: boolean | null;
+  activity_level?: BodyVitalsActivityLevel | null;
+  sleep_time?: string | null;
+  sleep_duration?: number | null;
+  start_of_day?: string | null;
+};
+
+export type BodyVitalsProteinGoal = {
+  total_requirement?: number | null;
+  meal_one?: number | null;
+  meal_two?: number | null;
+  meal_three?: number | null;
+  unit?: string | null;
+  protein_target_g?: number | null;
+  protein_per_meal_g?: number | null;
+  tip?: string | null;
+};
+
+export type BodyVitalsCalorieGoal = {
+  total_calorie?: number | null;
+  maintenance_calories?: number | null;
+  optimal_burn_calories?: number | null;
+  unit?: string | null;
+  maintaince?: number | null;
+  burn?: number | null;
+  build?: number | null;
+  tip?: string | null;
+};
+
+export type BodyVitalsDietGoal = {
+  carbs_goal?: number | null;
+  fats_goal?: number | null;
+  fiber_goal?: number | null;
+  tip?: string | null;
+};
+
+export type BodyVitalsProfile = {
+  height_cm?: number | null;
+  weight_kg?: number | null;
+  age?: number | null;
+  gender?: "male" | "female" | null;
+  gender_prefer_not_to_say?: boolean | null;
+  activity_level?: BodyVitalsActivityLevel | null;
+  sleep_time?: string | null;
+  sleep_duration?: number | null;
+  start_of_day?: string | null;
+  protein_goal?: BodyVitalsProteinGoal | null;
+  calorie_goal?: BodyVitalsCalorieGoal | null;
+  diet_goal?: BodyVitalsDietGoal | null;
+  bmr?: number | null;
+  body_shape_code?: string | null;
+  body_shape_label?: string | null;
+  body_shape_confidence?: number | null;
+  movement_strategy?: string | null;
+  metabolic_insight?: string | null;
+  vitals_formula_version?: string | null;
+  vitals_last_calculated_at?: string | null;
+  vitals_updated_at?: string | null;
+};
+
+export type BodyVitalsSavedSummary = {
+  is_generated?: boolean | null;
+  height_cm?: number | null;
+  weight_kg?: number | null;
+  age?: number | null;
+  gender?: "male" | "female" | null;
+  gender_prefer_not_to_say?: boolean | null;
+  calorie_goal?: number | null;
+  protein_goal?: number | null;
+  bmr?: number | null;
+  maintenance_calories?: number | null;
+  optimal_burn_calories?: number | null;
+  protein_target_g?: number | null;
+  protein_per_meal_g?: number | null;
+  body_shape_code?: string | null;
+  body_shape_label?: string | null;
+  body_shape_confidence?: number | null;
+  movement_strategy?: string | null;
+  metabolic_insight?: string | null;
+  vitals_formula_version?: string | null;
+  calculated_at?: string | null;
+};
+
+export type BodyVitalsCalculatorReadiness = {
+  protein?: boolean;
+  calories?: boolean;
+  body_shape?: boolean;
+};
+
+export type BodyVitalsBanner = {
+  show?: boolean | null;
+  message?: string | null;
+};
+
+export type BodyVitalsContext = {
+  profile?: BodyVitalsProfile | null;
+  prefill?: BodyVitalsPrefill | null;
+  saved_summary?: BodyVitalsSavedSummary | null;
+  missing_fields?: string[] | null;
+  profile_status?: string | null;
+  days_since_last_update?: number | null;
+  calculator_readiness?: BodyVitalsCalculatorReadiness | null;
+  banner?: BodyVitalsBanner | null;
+};
+
+export type BodyVitalsFormState = {
+  gender: SomaticGender;
+  age: string;
+  weight: string;
+  height: string;
+  activityLevel: number;
+};
+
+export type BodyVitalsUpdatePayload = {
+  calculation_type: "all";
+  save_to_profile: true;
+  vitals: {
+    gender: BodyVitalsApiGender;
+    age: number;
+    weight_kg: number;
+    height_cm: number;
+    activity_level: BodyVitalsApiActivityLevel;
+  };
+};

--- a/services/authSessionService.ts
+++ b/services/authSessionService.ts
@@ -1,0 +1,80 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import axios from "axios";
+import * as SecureStore from "expo-secure-store";
+
+import { StoreKey } from "@/constants/Constant";
+import { clearStoredBodyVitalsContext } from "@/features/self-care/services/bodyVitalsStorage";
+import { setStoredUser } from "@/services/storageService";
+
+export const AUTH_SESSION_DEFAULT_TIMEOUT_MS = 15 * 24 * 60 * 60 * 1000;
+export const AUTH_SESSION_TEST_TIMEOUT_MS = 15 * 60 * 1000;
+
+const TEST_MODE_KEY = StoreKey.AUTH_SESSION_TEST_MODE_KEY;
+
+async function clearAuthStorage() {
+  delete axios.defaults.headers.common["Authorization"];
+  await Promise.allSettled([
+    SecureStore.deleteItemAsync(StoreKey.TOKEN_KEY),
+    SecureStore.deleteItemAsync(StoreKey.REFRESH_TOKEN),
+    SecureStore.deleteItemAsync(StoreKey.ONBOARDING_DONE_KEY),
+    SecureStore.deleteItemAsync(StoreKey.LAST_ACTIVE_KEY),
+    clearStoredBodyVitalsContext(),
+    setStoredUser(null),
+  ]);
+}
+
+export async function clearAuthSession() {
+  await clearAuthStorage();
+}
+
+export async function getAuthSessionTestModeEnabled(): Promise<boolean> {
+  return (await AsyncStorage.getItem(TEST_MODE_KEY)) === "true";
+}
+
+export async function setAuthSessionTestModeEnabled(
+  enabled: boolean
+): Promise<void> {
+  if (enabled) {
+    await AsyncStorage.setItem(TEST_MODE_KEY, "true");
+    return;
+  }
+
+  await AsyncStorage.removeItem(TEST_MODE_KEY);
+}
+
+export async function getAuthSessionTimeoutMs(): Promise<number> {
+  const testModeEnabled = await getAuthSessionTestModeEnabled();
+  return testModeEnabled
+    ? AUTH_SESSION_TEST_TIMEOUT_MS
+    : AUTH_SESSION_DEFAULT_TIMEOUT_MS;
+}
+
+export async function touchAuthSessionActivity(): Promise<void> {
+  await SecureStore.setItemAsync(
+    StoreKey.LAST_ACTIVE_KEY,
+    String(Date.now())
+  );
+}
+
+export async function getFreshAuthTokenOrClearSession(): Promise<string | null> {
+  const token = await SecureStore.getItemAsync(StoreKey.TOKEN_KEY);
+  if (!token) return null;
+
+  const lastActiveRaw = await SecureStore.getItemAsync(StoreKey.LAST_ACTIVE_KEY);
+  const lastActive = Number(lastActiveRaw);
+
+  if (!lastActiveRaw || !Number.isFinite(lastActive)) {
+    await touchAuthSessionActivity();
+    return token;
+  }
+
+  const timeoutMs = await getAuthSessionTimeoutMs();
+  const isExpired = Date.now() - lastActive >= timeoutMs;
+
+  if (isExpired) {
+    await clearAuthStorage();
+    return null;
+  }
+
+  return token;
+}

--- a/services/storageService.ts
+++ b/services/storageService.ts
@@ -1,48 +1,55 @@
-// services/UserStorage.ts
+// services/storageService.ts
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as SecureStore from "expo-secure-store";
 
-const USER_KEY = "@nimbus_user";
-const TOKEN_KEY = "auth_token"; // if you need one
+import { StoreKey } from "@/constants/Constant";
+import type { UserProfile } from "@/features/auth/types/userProfile";
 
-export type User = {
-  id: number;
-  username: string;
-  email: string;
-  first_name?: string | null;
-  last_name?: string | null;
-  avatar?: string | null; // "svg:3" or "uri:https://..."
-  profile?: {
-    phone_number?: string | null;
-    height?: string | number | null;
-    weight?: string | number | null;
-    age?: number | null;
-    gender?: string | null;
-  };
-  settings?: {
-    weight_unit?: "kg" | "lbs";
-    height_unit?: "cm" | "in";
-    liquid_unit?: "ml" | "oz";
-    weather_unit?: "celsius" | "fahrenheit";
-    start_of_day?: string | null; // "06:00"
-    start_of_week?: "monday" | "sunday";
-    sleep_time?: string | null;
-    location?: string | null;
-  };
-  notifications?: any;
-};
+const USER_KEY = "@nimbus_user";
+const LEGACY_PROFILE_KEY = StoreKey.USER_PROFILE_KEY;
+const TOKEN_KEY = StoreKey.TOKEN_KEY;
+
+export type User = UserProfile;
+
+function parseStoredUser(raw: string | null): User | null {
+  if (!raw) return null;
+
+  try {
+    return JSON.parse(raw) as User;
+  } catch {
+    return null;
+  }
+}
+
+async function clearLegacyProfileCache() {
+  try {
+    await SecureStore.deleteItemAsync(LEGACY_PROFILE_KEY);
+  } catch {
+    // Ignore legacy cache cleanup failures; AsyncStorage is the source of truth.
+  }
+}
 
 export async function getStoredUser(): Promise<User | null> {
-  const raw = await AsyncStorage.getItem(USER_KEY);
-  return raw ? JSON.parse(raw) : null;
+  const cached = parseStoredUser(await AsyncStorage.getItem(USER_KEY));
+  if (cached) return cached;
+
+  const legacy = parseStoredUser(await SecureStore.getItemAsync(LEGACY_PROFILE_KEY));
+  if (!legacy) return null;
+
+  await AsyncStorage.setItem(USER_KEY, JSON.stringify(legacy));
+  await clearLegacyProfileCache();
+  return legacy;
 }
 
 export async function setStoredUser(user: User | null): Promise<void> {
   if (!user) {
     await AsyncStorage.removeItem(USER_KEY);
+    await clearLegacyProfileCache();
     return;
   }
+
   await AsyncStorage.setItem(USER_KEY, JSON.stringify(user));
+  await clearLegacyProfileCache();
 }
 
 export async function getToken(): Promise<string | null> {


### PR DESCRIPTION
## What changed
- Centralized body-vitals parsing and persistence so the body vitals, calorie, and protein screens all read from the same saved context.
- Added profile-backed body-vitals storage/migration and new helpers to build the body-vitals update payload.
- Updated the body vitals screen to prefill from saved data, save changes back through the profile update flow, and route calorie/protein panels with resolved data.
- Reworked auth/session handling to track last activity, expire stale sessions, clear local auth caches, and re-check freshness on app startup, app foreground, and authenticated API traffic.
- Added a developer-only auth test mode plus a manual reset action in Settings.
- Documented the auth-session logout behavior.

## Why
- The previous flow depended heavily on route params and local defaults, which made the body-vitals panels drift from the saved profile state.
- Session expiry and logout cleanup were split across multiple code paths, so stale tokens and cached profile data could survive longer than intended.

## Impact
- Users now see the same saved vitals data reflected across the self-care flow.
- Autologout is enforced from a single session layer, which reduces the chance of invalid tokens or stale local profile data remaining in the app.
- Development builds get a 15-minute timeout toggle and a manual reset path for quicker verification.

## Validation
- `npx jest --runInBand features/self-care/services/__tests__/bodyVitalsService.test.ts features/self-care/services/__tests__/caloriePanelService.test.ts features/self-care/services/__tests__/proteinPanelService.test.ts`
- `npx eslint -- app/index.tsx 'app/(auth)/(tabs)/settings.tsx' constants/Constant.ts contexts/AuthContext.tsx features/auth/types/userProfile.ts features/self-care/screens/BodyVitalScreen.tsx features/self-care/screens/CalorieThresholdScreen.tsx features/self-care/screens/ProteinCalculatorScreen.tsx services/storageService.ts services/authSessionService.ts features/self-care/services/bodyVitalsService.ts features/self-care/services/bodyVitalsStorage.ts features/self-care/services/caloriePanelService.ts features/self-care/services/proteinPanelService.ts features/self-care/types/bodyVitals.ts`
- `npm run lint` still reports a pre-existing unrelated hook error in `components/ui/InlinedTimePicker.tsx`
