### PR TITLE
[codex] integrate affirmation api with mock fallback

### DIFF
--- a/config/apiConfig.ts
+++ b/config/apiConfig.ts
@@ -69,6 +69,7 @@ export const API_ENDPOINTS = {
   getAudioBookList: `${BASE_URL}/api/v1/media/media-assets/?type=meditation&category=audioBook`,
   getMeditationList: `${BASE_URL}/api/v1/media/media-assets/?type=meditation&category=breathwork`,
   getWellnessContent: `${BASE_URL}/api/v1/wellness-content/`,
+  getAffirmations: `${BASE_URL}/api/v1/wellness-content/affirmations/`,
   getWellnessContentDetail: (id: number | string) =>
     `${BASE_URL}/api/v1/wellness-content/${id}/`,
   createWellnessSession: `${BASE_URL}/api/v1/wellness/sessions/`,

--- a/features/self-care/components/affirmation/AffirmationListCard.tsx
+++ b/features/self-care/components/affirmation/AffirmationListCard.tsx
@@ -31,8 +31,8 @@ const AffirmationListCard = ({
     useContext(ThemeContext);
 
   const palette = useMemo<AffirmationRecommendationPalette>(
-    () => getAffirmationRecommendationPaletteById(item.id),
-    [item.id]
+    () => getAffirmationRecommendationPaletteById(item.paletteKey ?? item.id),
+    [item.id, item.paletteKey]
   );
 
   const styles = useMemo(

--- a/features/self-care/components/affirmation/AffirmationStoryModal.tsx
+++ b/features/self-care/components/affirmation/AffirmationStoryModal.tsx
@@ -143,6 +143,10 @@ const AffirmationStoryModal = ({
 
   const slideWidth = Math.max(1, Math.round(width - spacing.md * 2));
   const sheetHeight = Math.min(Math.round(height * 0.9), 780);
+  const storyDeckLabel =
+    slides.length === 1
+      ? "1 slide to hold the mood."
+      : `${slides.length} slides to hold the mood.`;
 
   const initialIndex = useMemo(() => {
     const foundIndex = slides.findIndex((item) => item.id === initialSlideId);
@@ -304,7 +308,7 @@ const AffirmationStoryModal = ({
               <View style={styles.headerRow}>
                 <View style={styles.headerCopy}>
                   <Text style={styles.eyebrow}>AFFIRMATION STORY</Text>
-                  <Text style={styles.title}>Six slides to hold the mood.</Text>
+                  <Text style={styles.title}>{storyDeckLabel}</Text>
                   <Text style={styles.subtitle}>
                     Swipe horizontally through the selected line and the full deck.
                   </Text>

--- a/features/self-care/components/affirmation/__tests__/AffirmationStoryModal.test.tsx
+++ b/features/self-care/components/affirmation/__tests__/AffirmationStoryModal.test.tsx
@@ -84,7 +84,7 @@ describe("AffirmationStoryModal", () => {
     );
 
     expect(hasText(tree, "AFFIRMATION STORY")).toBe(true);
-    expect(hasText(tree, "Six slides to hold the mood.")).toBe(true);
+    expect(hasText(tree, "6 slides to hold the mood.")).toBe(true);
     expect(hasText(tree, "06 / 06")).toBe(true);
     expect(hasText(tree, "Steady Flame")).toBe(true);
     expect(hasText(tree, "Quiet Ground")).toBe(true);

--- a/features/self-care/screens/AffirmationScreen.tsx
+++ b/features/self-care/screens/AffirmationScreen.tsx
@@ -18,14 +18,17 @@ import ThemeContext from "@/contexts/ThemeContext";
 import AffirmationListCard from "@/features/self-care/components/affirmation/AffirmationListCard";
 import AffirmationStoryModal from "@/features/self-care/components/affirmation/AffirmationStoryModal";
 import AffirmationRecommendationSection from "@/features/self-care/components/affirmation/AffirmationRecommendationSection";
-import { AFFIRMATION_RECOMMENDATIONS } from "@/features/self-care/utils/affirmationLibrary";
 import {
-  AFFIRMATION_CARDS,
+  getAffirmations,
+  getMockAffirmationDeck,
+} from "@/features/self-care/services/affirmationService";
+import {
   AFFIRMATION_FILTERS,
   filterAffirmations,
   formatAffirmationToneLabel,
   type AffirmationTone,
 } from "@/features/self-care/utils/mindPractices";
+import type { AffirmationDeck } from "@/features/self-care/types/affirmation";
 import type {
   ColorSet,
   Spacing,
@@ -40,10 +43,14 @@ export const AffirmationScreen = () => {
   const { newTheme: theme, svaTypography, spacing, typography } =
     useContext(ThemeContext);
 
+  const fallbackAffirmationDeck = useMemo(() => getMockAffirmationDeck(), []);
+  const [affirmationDeck, setAffirmationDeck] = useState<AffirmationDeck>(
+    fallbackAffirmationDeck
+  );
   const [selectedTone, setSelectedTone] =
     useState<AffirmationFilterValue>("all");
   const [selectedAffirmationId, setSelectedAffirmationId] = useState<string>(
-    AFFIRMATION_RECOMMENDATIONS[0]?.id ?? ""
+    fallbackAffirmationDeck.recommendations[0]?.id ?? ""
   );
   const [storyVisible, setStoryVisible] = useState(false);
 
@@ -57,14 +64,34 @@ export const AffirmationScreen = () => {
   }, [navigation]);
 
   const visibleAffirmations = useMemo(
-    () => filterAffirmations(AFFIRMATION_CARDS, selectedTone),
-    [selectedTone]
+    () => filterAffirmations(affirmationDeck.cards, selectedTone),
+    [affirmationDeck.cards, selectedTone]
   );
 
   const visibleRecommendations = useMemo(
-    () => filterAffirmations(AFFIRMATION_RECOMMENDATIONS, selectedTone),
-    [selectedTone]
+    () => filterAffirmations(affirmationDeck.recommendations, selectedTone),
+    [affirmationDeck.recommendations, selectedTone]
   );
+
+  useEffect(() => {
+    let active = true;
+
+    const loadAffirmations = async () => {
+      const deck = await getAffirmations();
+
+      if (!active) {
+        return;
+      }
+
+      setAffirmationDeck(deck);
+    };
+
+    void loadAffirmations();
+
+    return () => {
+      active = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (
@@ -74,18 +101,26 @@ export const AffirmationScreen = () => {
     ) {
       setSelectedAffirmationId(
         visibleRecommendations[0]?.id ??
-          AFFIRMATION_RECOMMENDATIONS[0]?.id ??
+          affirmationDeck.recommendations[0]?.id ??
           ""
       );
     }
-  }, [selectedAffirmationId, visibleRecommendations]);
+  }, [
+    affirmationDeck.recommendations,
+    selectedAffirmationId,
+    visibleRecommendations,
+  ]);
 
   const selectedAffirmation = useMemo(
     () =>
       visibleRecommendations.find((item) => item.id === selectedAffirmationId) ??
       visibleRecommendations[0] ??
-      AFFIRMATION_RECOMMENDATIONS[0],
-    [selectedAffirmationId, visibleRecommendations]
+      affirmationDeck.recommendations[0],
+    [
+      affirmationDeck.recommendations,
+      selectedAffirmationId,
+      visibleRecommendations,
+    ]
   );
 
   const listAffirmations = useMemo(
@@ -199,7 +234,7 @@ export const AffirmationScreen = () => {
         <AffirmationStoryModal
           visible={storyVisible}
           onClose={handleCloseStory}
-          slides={AFFIRMATION_RECOMMENDATIONS}
+          slides={affirmationDeck.recommendations}
           initialSlideId={selectedAffirmation?.id}
         />
       </View>

--- a/features/self-care/screens/__tests__/AffirmationScreen.test.tsx
+++ b/features/self-care/screens/__tests__/AffirmationScreen.test.tsx
@@ -6,6 +6,10 @@ import ThemeContext from "../../../../contexts/ThemeContext";
 import { ROUTES } from "../../../../constants/routes";
 import { getTheme } from "../../../../theme";
 import AffirmationScreen from "../AffirmationScreen";
+import {
+  getAffirmations,
+  getMockAffirmationDeck,
+} from "@/features/self-care/services/affirmationService";
 
 const mockBack = jest.fn();
 const mockPush = jest.fn();
@@ -48,6 +52,17 @@ jest.mock("react-native-safe-area-context", () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 
+jest.mock("@/features/self-care/services/affirmationService", () => {
+  const actual = jest.requireActual(
+    "@/features/self-care/services/affirmationService"
+  );
+
+  return {
+    ...actual,
+    getAffirmations: jest.fn(),
+  };
+});
+
 const theme = getTheme("sva");
 const themeValue = {
   theme: "sva",
@@ -73,15 +88,17 @@ const hasText = (tree: renderer.ReactTestRenderer, value: string) =>
         : node.props.children === value
     );
 
-function renderScreen() {
+async function renderScreen() {
   let tree!: renderer.ReactTestRenderer;
 
-  act(() => {
+  await act(async () => {
     tree = renderer.create(
       <ThemeContext.Provider value={themeValue as any}>
         <AffirmationScreen />
       </ThemeContext.Provider>
     );
+
+    await Promise.resolve();
   });
 
   return tree;
@@ -90,14 +107,16 @@ function renderScreen() {
 describe("AffirmationScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (getAffirmations as jest.Mock).mockResolvedValue(getMockAffirmationDeck());
   });
 
-  it("renders the recommendation row and list content", () => {
-    const tree = renderScreen();
+  it("renders the recommendation row and list content", async () => {
+    const tree = await renderScreen();
 
     expect(mockSetOptions).toHaveBeenCalledWith({
       headerShown: false,
     });
+    expect(getAffirmations).toHaveBeenCalledTimes(1);
 
     expect(hasText(tree, "Affirmations")).toBe(true);
     expect(hasText(tree, "RECOMMENDED LINE")).toBe(true);
@@ -111,8 +130,8 @@ describe("AffirmationScreen", () => {
     expect(hasText(tree, "CALM")).toBe(true);
   });
 
-  it("opens the story modal when a card is pressed", () => {
-    const tree = renderScreen();
+  it("opens the story modal when a card is pressed", async () => {
+    const tree = await renderScreen();
 
     const card = tree.root.findByProps({
       accessibilityLabel: "Choose affirmation open-space",
@@ -132,8 +151,8 @@ describe("AffirmationScreen", () => {
     ).toBe(true);
   });
 
-  it("opens the custom affirmation screen from the pencil action", () => {
-    const tree = renderScreen();
+  it("opens the custom affirmation screen from the pencil action", async () => {
+    const tree = await renderScreen();
 
     const pencil = tree.root.findByProps({
       accessibilityLabel: "Create custom affirmation",

--- a/features/self-care/services/__tests__/affirmationService.test.ts
+++ b/features/self-care/services/__tests__/affirmationService.test.ts
@@ -1,0 +1,110 @@
+import axios from "axios";
+
+import { API_ENDPOINTS } from "@/config/apiConfig";
+
+import {
+  getAffirmations,
+  getMockAffirmationDeck,
+} from "../affirmationService";
+
+jest.mock("axios", () => ({
+  get: jest.fn(),
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("affirmationService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("maps the affirmations payload into the app deck shape", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: "Affirmations retrieved successfully.",
+        data: [
+          {
+            id: "quiet-power-ii",
+            tone: "confidence",
+            quotes: {
+              quote_title: "Quiet Power ii",
+              tags: ["focus", "study"],
+              quote_content: [
+                "Steady energy is stronger than rushed effort.",
+              ],
+            },
+            quote_detail:
+              "A cleaner rhythm for focus, study, and follow-through.",
+          },
+          {
+            id: "quiet-power",
+            tone: "confidence",
+            quotes: {
+              quote_title: "Quiet Power",
+              tags: ["focus", "study"],
+              quote_content: [
+                "Steady energy is stronger than rushed effort.",
+              ],
+            },
+            quote_detail:
+              "A cleaner rhythm for focus, study, and follow-through.",
+          },
+        ],
+        pagination: {
+          count: 2,
+          next: null,
+          previous: null,
+          page: 1,
+          page_size: 100,
+          total_pages: 1,
+          results_count: 2,
+        },
+      },
+    });
+
+    const deck = await getAffirmations();
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      API_ENDPOINTS.getAffirmations
+    );
+    expect(deck.source).toBe("api");
+    expect(deck.message).toBe("Affirmations retrieved successfully.");
+    expect(deck.cards).toEqual([
+      {
+        id: "quiet-power-ii",
+        tone: "confidence",
+        quote: "Steady energy is stronger than rushed effort.",
+        detail: "A cleaner rhythm for focus, study, and follow-through.",
+        paletteKey: "steady-breath",
+      },
+      {
+        id: "quiet-power",
+        tone: "confidence",
+        quote: "Steady energy is stronger than rushed effort.",
+        detail: "A cleaner rhythm for focus, study, and follow-through.",
+        paletteKey: "clear-steps",
+      },
+    ]);
+    expect(deck.recommendations[0]).toMatchObject({
+      id: "quiet-power-ii",
+      tone: "confidence",
+      title: "Quiet Power ii",
+      affirmation: "Steady energy is stronger than rushed effort.",
+      tag: "Focus",
+    });
+  });
+
+  it("falls back to the mock deck when the API request fails", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    mockedAxios.get.mockRejectedValueOnce(new Error("network down"));
+
+    const deck = await getAffirmations();
+
+    expect(deck).toEqual(getMockAffirmationDeck());
+    expect(deck.source).toBe("mock");
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});

--- a/features/self-care/services/affirmationService.ts
+++ b/features/self-care/services/affirmationService.ts
@@ -1,0 +1,207 @@
+import axios from "axios";
+
+import { API_ENDPOINTS } from "@/config/apiConfig";
+import {
+  AFFIRMATION_RECOMMENDATIONS,
+  type AffirmationRecommendation,
+} from "@/features/self-care/utils/affirmationLibrary";
+import {
+  AFFIRMATION_CARDS,
+  formatAffirmationToneLabel,
+  type AffirmationTone,
+} from "@/features/self-care/utils/mindPractices";
+import type {
+  AffirmationApiItem,
+  AffirmationApiResponse,
+  AffirmationDeck,
+} from "@/features/self-care/types/affirmation";
+
+const FALLBACK_SOURCE_MESSAGE = "Mock affirmations loaded for now.";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toText(value: unknown, fallback: string) {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function toTextList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((item) => (typeof item === "string" ? item.trim() : ""))
+    .filter(Boolean);
+}
+
+function joinQuoteContent(value: unknown, fallback: string) {
+  const items = toTextList(value);
+  return items.length > 0 ? items.join(" ") : fallback;
+}
+
+function formatTagLabel(value: string) {
+  const normalized = value.trim();
+
+  if (!normalized) {
+    return "";
+  }
+
+  return normalized
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function normalizeAffirmationTone(
+  tone: unknown,
+  tags: string[] = []
+): AffirmationTone {
+  if (typeof tone === "string") {
+    const normalizedTone = tone.trim().toLowerCase();
+    if (
+      normalizedTone === "calm" ||
+      normalizedTone === "confidence" ||
+      normalizedTone === "reset" ||
+      normalizedTone === "sleep"
+    ) {
+      return normalizedTone;
+    }
+  }
+
+  const normalizedTags = tags.map((tag) => tag.trim().toLowerCase());
+
+  if (
+    normalizedTags.some((tag) =>
+      ["sleep", "rest", "night", "dream"].includes(tag)
+    )
+  ) {
+    return "sleep";
+  }
+
+  if (
+    normalizedTags.some((tag) =>
+      ["reset", "restart", "release", "cleanse"].includes(tag)
+    )
+  ) {
+    return "reset";
+  }
+
+  if (
+    normalizedTags.some((tag) =>
+      ["calm", "ground", "breathe", "breath", "quiet"].includes(tag)
+    )
+  ) {
+    return "calm";
+  }
+
+  return "confidence";
+}
+
+function getPaletteSeed(index: number) {
+  return (
+    AFFIRMATION_RECOMMENDATIONS[index % AFFIRMATION_RECOMMENDATIONS.length] ??
+    AFFIRMATION_RECOMMENDATIONS[0]
+  );
+}
+
+function normalizeAffirmationApiItem(
+  item: AffirmationApiItem,
+  index: number
+): {
+  card: (typeof AFFIRMATION_CARDS)[number];
+  recommendation: AffirmationRecommendation;
+} {
+  const paletteSeed = getPaletteSeed(index);
+  const quoteTags = toTextList(item.quotes?.tags);
+  const tone = normalizeAffirmationTone(item.tone, quoteTags);
+  const id = toText(item.id, `${paletteSeed.id}-${index}`);
+  const title = toText(
+    item.quotes?.quote_title,
+    formatAffirmationToneLabel(tone)
+  );
+  const quote = joinQuoteContent(
+    item.quotes?.quote_content,
+    title
+  );
+  const detail = toText(item.quote_detail, quote);
+  const tag = formatTagLabel(quoteTags[0] ?? tone);
+
+  return {
+    card: {
+      id,
+      tone,
+      quote,
+      detail,
+      paletteKey: paletteSeed.id,
+    },
+    recommendation: {
+      id,
+      tone,
+      title,
+      affirmation: quote,
+      tag: tag || formatAffirmationToneLabel(tone),
+      palette: paletteSeed.palette,
+    },
+  };
+}
+
+function buildMockAffirmationDeck(): AffirmationDeck {
+  return {
+    cards: AFFIRMATION_CARDS.map((card, index) => ({
+      ...card,
+      paletteKey:
+        AFFIRMATION_RECOMMENDATIONS[index % AFFIRMATION_RECOMMENDATIONS.length]
+          ?.id ?? card.id,
+    })),
+    recommendations: AFFIRMATION_RECOMMENDATIONS,
+    source: "mock",
+    message: FALLBACK_SOURCE_MESSAGE,
+  };
+}
+
+function normalizeAffirmationDeck(
+  payload: AffirmationApiResponse | null | undefined
+): AffirmationDeck | null {
+  if (!payload?.success || !Array.isArray(payload.data) || payload.data.length === 0) {
+    return null;
+  }
+
+  const normalized = payload.data
+    .filter((item) => isRecord(item))
+    .map((item, index) => normalizeAffirmationApiItem(item as AffirmationApiItem, index));
+
+  if (!normalized.length) {
+    return null;
+  }
+
+  return {
+    cards: normalized.map((item) => item.card),
+    recommendations: normalized.map((item) => item.recommendation),
+    source: "api",
+    message: payload.message,
+  };
+}
+
+export function getMockAffirmationDeck(): AffirmationDeck {
+  return buildMockAffirmationDeck();
+}
+
+export async function getAffirmations(): Promise<AffirmationDeck> {
+  try {
+    const response = await axios.get<AffirmationApiResponse>(
+      API_ENDPOINTS.getAffirmations
+    );
+
+    const normalized = normalizeAffirmationDeck(response.data);
+    if (normalized) {
+      return normalized;
+    }
+  } catch (error) {
+    console.warn("Failed to load affirmations from API, using mock deck.", error);
+  }
+
+  return buildMockAffirmationDeck();
+}

--- a/features/self-care/types/affirmation.ts
+++ b/features/self-care/types/affirmation.ts
@@ -1,0 +1,39 @@
+import type { AffirmationRecommendation } from "@/features/self-care/utils/affirmationLibrary";
+import type { AffirmationCard } from "@/features/self-care/utils/mindPractices";
+
+export type AffirmationApiQuote = {
+  quote_title?: string | null;
+  tags?: string[] | null;
+  quote_content?: string[] | null;
+};
+
+export type AffirmationApiItem = {
+  id?: string | null;
+  tone?: string | null;
+  quotes?: AffirmationApiQuote | null;
+  quote_detail?: string | null;
+};
+
+export type AffirmationApiPagination = {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  page: number;
+  page_size: number;
+  total_pages: number;
+  results_count: number;
+};
+
+export type AffirmationApiResponse = {
+  success: boolean;
+  message: string;
+  data: AffirmationApiItem[];
+  pagination?: AffirmationApiPagination | null;
+};
+
+export type AffirmationDeck = {
+  cards: AffirmationCard[];
+  recommendations: AffirmationRecommendation[];
+  source: "api" | "mock";
+  message: string;
+};

--- a/features/self-care/utils/mindPractices.ts
+++ b/features/self-care/utils/mindPractices.ts
@@ -5,6 +5,7 @@ export type AffirmationCard = {
   tone: AffirmationTone;
   quote: string;
   detail: string;
+  paletteKey?: string;
 };
 
 export const AFFIRMATION_CARDS: AffirmationCard[] = [


### PR DESCRIPTION
## What changed
- Added a dedicated affirmations service for `GET /api/v1/wellness-content/affirmations/`.
- Normalized the API payload into the existing affirmation card/recommendation shapes used by the UI.
- Kept the current mock affirmation deck as a fallback when the API fails or returns no usable items.
- Wired the affirmation screen to load the API deck on mount while preserving the existing library/story UI.
- Updated the story modal copy to use the live slide count instead of hard-coding six slides.

## Why
- The affirmation screen was fully local, so the app could not yet reflect backend-managed affirmation content.
- The fallback path keeps the screen usable while the endpoint is still being validated.

## Impact
- If the API responds successfully, the affirmation screen now shows the server-provided quotes.
- If the API request fails, the app continues to render the current mock deck so testing can continue without blocking on backend availability.
- Existing tone filtering, recommendation cards, and story modal interactions still work with either data source.

## Validation
- `npx jest --runInBand features/self-care/services/__tests__/affirmationService.test.ts features/self-care/screens/__tests__/AffirmationScreen.test.tsx features/self-care/components/affirmation/__tests__/AffirmationStoryModal.test.tsx features/self-care/components/affirmation/__tests__/AffirmationListCard.test.tsx features/self-care/components/affirmation/__tests__/AffirmationRecommendationCard.test.tsx`
- `npx eslint -- config/apiConfig.ts features/self-care/types/affirmation.ts features/self-care/services/affirmationService.ts features/self-care/screens/AffirmationScreen.tsx features/self-care/components/affirmation/AffirmationListCard.tsx features/self-care/components/affirmation/AffirmationStoryModal.tsx features/self-care/screens/__tests__/AffirmationScreen.test.tsx features/self-care/components/affirmation/__tests__/AffirmationStoryModal.test.tsx features/self-care/services/__tests__/affirmationService.test.ts features/self-care/utils/mindPractices.ts`
